### PR TITLE
Improve accessibility and styling of language switcher

### DIFF
--- a/components/LanguageSwitcher.tsx
+++ b/components/LanguageSwitcher.tsx
@@ -14,7 +14,7 @@ export default function LanguageSwitcher() {
 
   return (
     <nav aria-label="Language selector">
-      <ul>
+      <ul className="flex gap-2">
         {(locales ?? []).map((code) => {
           const label = localeLabels[code] ?? code
           const isActive = activeLocale === code
@@ -24,11 +24,8 @@ export default function LanguageSwitcher() {
                 href={{ pathname, query }}
                 locale={code}
                 aria-label={`Switch to ${label}`}
-                aria-current={isActive ? 'true' : undefined}
-                style={{
-                  marginRight: 8,
-                  fontWeight: isActive ? 'bold' : 'normal'
-                }}
+                aria-current={isActive ? 'page' : undefined}
+                className={isActive ? 'font-bold' : 'font-normal'}
               >
                 {label}
               </Link>

--- a/test/LanguageSwitcher.test.js
+++ b/test/LanguageSwitcher.test.js
@@ -44,8 +44,10 @@ test('LanguageSwitcher sets aria-label and aria-current correctly', () => {
   assert.ok(nav, 'nav with aria-label "Language selector" should exist');
 
   const active = screen.getByRole('link', { name: 'Switch to English' });
-  assert.strictEqual(active.getAttribute('aria-current'), 'true');
+  assert.strictEqual(active.getAttribute('aria-current'), 'page');
+  assert.strictEqual(active.className, 'font-bold');
 
   const other = screen.getByRole('link', { name: 'Switch to ไทย' });
   assert.strictEqual(other.getAttribute('aria-current'), null);
+  assert.strictEqual(other.className, 'font-normal');
 });


### PR DESCRIPTION
## Summary
- use `aria-current="page"` for the active language link
- replace inline styles with Tailwind classes for font weight and spacing
- update tests for new markup

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6d58f4488832ba8a9bb494f5d2b3b