### PR TITLE
Add custom Next.js server and enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start",
+    "start": "node server.js",
     "test": "node --test",
     "lint": "next lint",
     "postbuild": "next-sitemap"

--- a/server.js
+++ b/server.js
@@ -1,0 +1,29 @@
+const { createServer } = require('http');
+const { parse } = require('url');
+const next = require('next');
+const fs = require('fs');
+const path = require('path');
+
+const dev = process.env.NODE_ENV !== 'production';
+const app = next({ dev });
+const handle = app.getRequestHandler();
+
+// Ensure the uploads directory exists and is writable
+const uploadDir = path.join(__dirname, 'public', 'uploads');
+
+app.prepare().then(() => {
+  fs.mkdirSync(uploadDir, { recursive: true });
+  try {
+    fs.chmodSync(uploadDir, 0o755);
+  } catch (err) {
+    console.error(`Failed to set permissions for ${uploadDir}:`, err);
+  }
+
+  createServer((req, res) => {
+    const parsedUrl = parse(req.url, true);
+    handle(req, res, parsedUrl);
+  }).listen(3000, (err) => {
+    if (err) throw err;
+    console.log('> Ready on http://localhost:3000');
+  });
+});


### PR DESCRIPTION
## Summary
- add custom HTTP server to boot Next.js and ensure `/public/uploads` exists at runtime
- run Next.js using `node server.js`
- enforce LF line endings via `.gitattributes`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6f3f2e120832b9b255411b3e11c87