### PR TITLE
Add currency rate updater

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,19 @@ You can also run just the postbuild step manually:
 ```bash
 npm run postbuild
 ```
+
+## Exchange rates
+
+Refresh currency conversion data used by the site:
+
+```bash
+npm run update-rates
+```
+
+This script downloads the latest daily rates from the European Central Bank
+and writes them to `public/data/rates.json`. If the network request fails, the
+existing file remains unchanged.
+
 ## Locale detection
 
 Language detection is handled by [`middleware.ts`](middleware.ts). When a path

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "node server.js",
     "test": "node --test",
     "lint": "next lint",
-    "postbuild": "next-sitemap"
+    "postbuild": "next-sitemap",
+    "update-rates": "ts-node --compiler-options '{\"module\":\"CommonJS\"}' src/lib/fx/updateRates.ts"
   },
   "dependencies": {
     "autoprefixer": "^10.4.21",

--- a/src/lib/fx/updateRates.ts
+++ b/src/lib/fx/updateRates.ts
@@ -1,0 +1,40 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import type { Rates } from './convert';
+
+const ECB_URL = 'https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml';
+
+export async function updateRates(): Promise<void> {
+  try {
+    const res = await fetch(ECB_URL);
+    if (!res.ok) {
+      throw new Error(`unexpected response ${res.status}`);
+    }
+    const xml = await res.text();
+    const ecbRates: Record<string, number> = {};
+    const regex = /currency='([A-Z]{3})'\s+rate='([0-9.]+)'/g;
+    let match: RegExpExecArray | null;
+    while ((match = regex.exec(xml)) !== null) {
+      const [, currency, rate] = match;
+      ecbRates[currency] = parseFloat(rate);
+    }
+    const thbPerEur = ecbRates['THB'];
+    if (!thbPerEur) {
+      throw new Error('THB rate not found');
+    }
+    const rates: Rates = { THB: 1 };
+    for (const [currency, perEur] of Object.entries(ecbRates)) {
+      if (currency === 'THB') continue;
+      rates[currency] = parseFloat((perEur / thbPerEur).toFixed(3));
+    }
+    const filePath = path.join(process.cwd(), 'public', 'data', 'rates.json');
+    await fs.writeFile(filePath, JSON.stringify(rates, null, 2) + '\n');
+  } catch (err) {
+    console.warn('Skipping rate update:', err);
+  }
+}
+
+updateRates();
+
+export default updateRates;


### PR DESCRIPTION
## Summary
- add `updateRates` script to download ECB currency rates and write `public/data/rates.json`
- document how to refresh exchange rates
- expose `npm run update-rates` command for developers

## Testing
- `npm run update-rates` (fails: connect ENETUNREACH)
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6f4bef0ac832b9da090f2d78030c6