### PR TITLE
Add search query validation

### DIFF
--- a/src/lib/validation/search.ts
+++ b/src/lib/validation/search.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod';
+
+const safeString = z.string().trim().regex(/^[\p{L}\p{N}\s-]+$/u);
+
+export const searchParamsSchema = z.object({
+  query: safeString.optional(),
+  province: safeString.optional(),
+  type: safeString.optional(),
+  minPrice: z.coerce.number().int().nonnegative().optional(),
+  maxPrice: z.coerce.number().int().nonnegative().optional(),
+  beds: z.coerce.number().int().nonnegative().optional(),
+  baths: z.coerce.number().int().nonnegative().optional(),
+  status: z.enum(['sale', 'rent']).optional(),
+  freshness: z.coerce.number().int().nonnegative().optional(),
+  nearTransit: z.coerce.boolean().optional(),
+  furnished: z.enum(['furnished', 'unfurnished']).optional(),
+  sort: z.enum(['price-asc', 'price-desc', 'created-asc', 'created-desc']).optional(),
+  amenities: z
+    .union([safeString, z.array(safeString)])
+    .transform((val) => (Array.isArray(val) ? val : [val]))
+    .optional(),
+  transitLine: safeString.optional(),
+  transitStation: safeString.optional(),
+  page: z.coerce.number().int().positive().optional(),
+  pageSize: z.coerce.number().int().positive().max(100).optional(),
+});
+
+export type SearchParams = z.infer<typeof searchParamsSchema>;
+
+export const filterParamsSchema = searchParamsSchema.pick({
+  minPrice: true,
+  maxPrice: true,
+  beds: true,
+  baths: true,
+  status: true,
+  freshness: true,
+  nearTransit: true,
+  furnished: true,
+  sort: true,
+  amenities: true,
+  transitLine: true,
+  transitStation: true,
+});


### PR DESCRIPTION
## Summary
- add shared zod schemas for search filters with sanitization
- validate search parameters in properties page, search worker, and new API endpoint
- allow Unicode characters in safe string sanitizer

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6f853c998832ba86d39f2875f504b