### PR TITLE
feat: improve structured data and sitemaps

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,14 +1,42 @@
 /** @type {import('next-sitemap').IConfig} */
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://www.virintira.com'
+
 module.exports = {
-  siteUrl: process.env.NEXT_PUBLIC_SITE_URL || 'https://www.virintira.com',
+  siteUrl,
   generateRobotsTxt: true,
   i18n: {
     defaultLocale: 'th',
     locales: ['th', 'en', 'zh'],
   },
   alternateRefs: [
-    { href: 'https://www.virintira.com/th', hreflang: 'th' },
-    { href: 'https://www.virintira.com/en', hreflang: 'en' },
-    { href: 'https://www.virintira.com/zh', hreflang: 'zh' },
+    { href: `${siteUrl}/th`, hreflang: 'th' },
+    { href: `${siteUrl}/en`, hreflang: 'en' },
+    { href: `${siteUrl}/zh`, hreflang: 'zh' },
   ],
-};
+  /**
+   * Remove query params from sitemap URLs
+   */
+  transform: async (config, url) => {
+    const loc = url.split('?')[0]
+    return {
+      loc,
+      changefreq: 'daily',
+      priority: 0.7,
+      lastmod: config.autoLastmod ? new Date().toISOString() : undefined,
+      alternateRefs: config.alternateRefs ?? [],
+    }
+  },
+  robotsTxtOptions: {
+    policies: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: ['/adminmanager', '/*?*'],
+      },
+    ],
+    additionalSitemaps: [
+      `${siteUrl}/sitemap-properties.xml`,
+      `${siteUrl}/sitemap-guides.xml`,
+    ],
+  },
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "node server.js",
     "test": "node --test",
     "lint": "next lint",
-    "postbuild": "next-sitemap",
+    "postbuild": "next-sitemap && node scripts/section-sitemaps.js",
     "update-rates": "ts-node --compiler-options '{\"module\":\"CommonJS\"}' src/lib/fx/updateRates.ts"
   },
   "dependencies": {

--- a/pages/[locale]/guides/[slug].tsx
+++ b/pages/[locale]/guides/[slug].tsx
@@ -5,6 +5,7 @@ import { MDXRemote, MDXRemoteSerializeResult } from 'next-mdx-remote'
 import { serialize } from 'next-mdx-remote/serialize'
 import { useRouter } from 'next/router'
 import { NextSeo, ArticleJsonLd } from 'next-seo'
+import { getSeoUrls, getLanguageAlternates } from '@/lib/seo'
 
 interface ArticleData {
   slug: string
@@ -25,13 +26,18 @@ export default function GuideDetail({ source, article }: Props) {
   const lang = Array.isArray(router.query.locale)
     ? router.query.locale[0]
     : (router.query.locale as string)
-  const url = `/${lang}/guides/${article.slug}`
+  const { pageUrl } = getSeoUrls(lang, `/guides/${article.slug}`)
 
   return (
     <div>
-      <NextSeo title={article.title} openGraph={{ images: [{ url: article.coverImage }] }} />
+      <NextSeo
+        title={article.title}
+        canonical={pageUrl}
+        openGraph={{ images: [{ url: article.coverImage }] }}
+        languageAlternates={getLanguageAlternates(`/guides/${article.slug}`)}
+      />
       <ArticleJsonLd
-        url={url}
+        url={pageUrl}
         title={article.title}
         images={[article.coverImage]}
         datePublished={article.publishedAt}

--- a/pages/[locale]/guides/index.tsx
+++ b/pages/[locale]/guides/index.tsx
@@ -5,6 +5,9 @@ import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
 import MiniSearch from 'minisearch'
+import { NextSeo } from 'next-seo'
+import Script from 'next/script'
+import { getSeoUrls, getLanguageAlternates } from '@/lib/seo'
 
 interface Article {
   slug: string
@@ -25,6 +28,7 @@ export default function GuidesList({ articles, categories }: Props) {
   const lang = Array.isArray(router.query.locale)
     ? router.query.locale[0]
     : (router.query.locale as string)
+  const { pageUrl } = getSeoUrls(lang, '/guides')
 
   const [query, setQuery] = useState('')
   const [category, setCategory] = useState('')
@@ -67,6 +71,11 @@ export default function GuidesList({ articles, categories }: Props) {
 
   return (
     <div>
+      <NextSeo
+        title='Guides'
+        canonical={pageUrl}
+        languageAlternates={getLanguageAlternates('/guides')}
+      />
       <h1>Guides</h1>
       <input
         value={query}
@@ -91,6 +100,23 @@ export default function GuidesList({ articles, categories }: Props) {
           </li>
         ))}
       </ul>
+      {results.length > 0 && (
+        <Script
+          id='guides-itemlist'
+          type='application/ld+json'
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              '@context': 'https://schema.org',
+              '@type': 'ItemList',
+              itemListElement: results.map((a, i) => ({
+                '@type': 'ListItem',
+                position: i + 1,
+                url: `/${lang}/guides/${a.slug}`,
+              })),
+            }).replace(/</g, '\\u003c'),
+          }}
+        />
+      )}
     </div>
   )
 }

--- a/pages/[locale]/properties/[id].tsx
+++ b/pages/[locale]/properties/[id].tsx
@@ -3,7 +3,10 @@ import path from 'path'
 import { GetStaticPaths, GetStaticProps } from 'next'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
+import { NextSeo } from 'next-seo'
+import Script from 'next/script'
 import PropertyImage from '@/src/components/PropertyImage'
+import { getSeoUrls, getLanguageAlternates } from '@/lib/seo'
 
 interface Property {
   id: number
@@ -38,9 +41,15 @@ export default function PropertyDetail({ property, articles }: Props) {
   const related = articles.filter(
     (a) => a.category === property.type || a.provinces.includes(property.province.en)
   )
+  const { pageUrl } = getSeoUrls(lang, `/properties/${property.id}`)
 
   return (
     <div>
+      <NextSeo
+        title={title}
+        canonical={pageUrl}
+        languageAlternates={getLanguageAlternates(`/properties/${property.id}`)}
+      />
       <div>
         {property.images.length > 0 ? (
           property.images.map((img, i) => (
@@ -61,6 +70,30 @@ export default function PropertyDetail({ property, articles }: Props) {
           </li>
         ))}
       </ul>
+      <Script
+        id='realestate-listing'
+        type='application/ld+json'
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'RealEstateListing',
+            url: pageUrl,
+            name: title,
+            description: title,
+            address: {
+              '@type': 'PostalAddress',
+              addressRegion: provinceName,
+              addressCountry: 'TH',
+            },
+            offers: {
+              '@type': 'Offer',
+              price: property.price,
+              priceCurrency: 'THB',
+            },
+            image: property.images,
+          }).replace(/</g, '\\u003c'),
+        }}
+      />
     </div>
   )
 }

--- a/pages/[locale]/search/index.tsx
+++ b/pages/[locale]/search/index.tsx
@@ -1,0 +1,21 @@
+import { NextSeo } from 'next-seo'
+import { useRouter } from 'next/router'
+import { getSeoUrls, getLanguageAlternates } from '@/lib/seo'
+
+export default function SearchPage() {
+  const { locale, defaultLocale } = useRouter()
+  const lang = locale || defaultLocale || 'th'
+  const { pageUrl } = getSeoUrls(lang, '/search')
+
+  return (
+    <>
+      <NextSeo
+        title='Search'
+        canonical={pageUrl}
+        noindex
+        languageAlternates={getLanguageAlternates('/search')}
+      />
+      <h1>Search</h1>
+    </>
+  )
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,7 +6,6 @@ import {
   LocalBusinessJsonLd,
   WebPageJsonLd,
   BreadcrumbJsonLd,
-  SiteLinksSearchBoxJsonLd,
 } from 'next-seo'
 import { useRouter } from 'next/router'
 import Script from 'next/script'
@@ -83,14 +82,21 @@ export default function Home() {
           dayOfWeek: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'],
         }]}
       />
-      <SiteLinksSearchBoxJsonLd
-        url={siteUrl}
-        potentialActions={[
-          {
-            target: `${siteUrl}/search?query={search_term_string}`,
-            queryInput: 'search_term_string',
-          },
-        ]}
+      <Script
+        id='website'
+        type='application/ld+json'
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'WebSite',
+            url: siteUrl,
+            potentialAction: {
+              '@type': 'SearchAction',
+              target: `${siteUrl}/search?query={search_term_string}`,
+              'query-input': 'required name=search_term_string',
+            },
+          }).replace(/</g, '\\u003c'),
+        }}
       />
       {/* eslint-disable-next-line react/no-danger */}
       <Script

--- a/pages/properties.tsx
+++ b/pages/properties.tsx
@@ -1,8 +1,11 @@
-import { useEffect, useState } from 'react';
-import { useRouter } from 'next/router';
-import PropertyFilters, { Filters } from '../src/components/PropertyFilters';
-import PropertyCard from '../src/components/PropertyCard';
-import { filterParamsSchema } from '../src/lib/validation/search';
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/router'
+import { NextSeo } from 'next-seo'
+import Script from 'next/script'
+import PropertyFilters, { Filters } from '../src/components/PropertyFilters'
+import PropertyCard from '../src/components/PropertyCard'
+import { filterParamsSchema } from '../src/lib/validation/search'
+import { getLanguageAlternates, getSeoUrls } from '../lib/seo'
 
 interface SearchResponse {
   total: number;
@@ -10,19 +13,20 @@ interface SearchResponse {
 }
 
 export default function PropertySearchPage() {
-  const router = useRouter();
-  const locale = router.locale || router.defaultLocale || 'en';
-  const [filters, setFilters] = useState<Filters>({});
-  const [results, setResults] = useState<any[]>([]);
+  const router = useRouter()
+  const locale = router.locale || router.defaultLocale || 'en'
+  const [filters, setFilters] = useState<Filters>({})
+  const [results, setResults] = useState<any[]>([])
+  const { pageUrl } = getSeoUrls(locale, '/properties')
 
   const runSearch = (f: Filters) => {
-    const worker = new Worker(new URL('../src/workers/search.worker.ts', import.meta.url));
+    const worker = new Worker(new URL('../src/workers/search.worker.ts', import.meta.url))
     worker.onmessage = (e: MessageEvent<SearchResponse>) => {
-      setResults(e.data.results);
-      worker.terminate();
-    };
-    worker.postMessage({ query: '', ...f });
-  };
+      setResults(e.data.results)
+      worker.terminate()
+    }
+    worker.postMessage({ query: '', ...f })
+  }
 
   useEffect(() => {
     const parsed = filterParamsSchema.safeParse(router.query);
@@ -37,23 +41,45 @@ export default function PropertySearchPage() {
   }, []);
 
   const handleChange = (f: Filters) => {
-    const safe = filterParamsSchema.parse(f) as Filters;
-    setFilters(safe);
+    const safe = filterParamsSchema.parse(f) as Filters
+    setFilters(safe)
     const query = Object.fromEntries(
       Object.entries(safe).filter(([, v]) => v !== undefined && v !== '' && !(Array.isArray(v) && v.length === 0))
-    );
-    router.replace({ pathname: router.pathname, query }, undefined, { shallow: true });
-    runSearch(safe);
-  };
+    )
+    router.replace({ pathname: router.pathname, query }, undefined, { shallow: true })
+    runSearch(safe)
+  }
 
   return (
-    <div className="p-4 space-y-4">
+    <div className='p-4 space-y-4'>
+      <NextSeo
+        title='Property Listings'
+        canonical={pageUrl}
+        languageAlternates={getLanguageAlternates('/properties')}
+      />
       <PropertyFilters filters={filters} onChange={handleChange} />
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <div className='grid grid-cols-1 md:grid-cols-2 gap-4'>
         {results.map((p) => (
           <PropertyCard key={p.id} property={p} locale={locale} />
         ))}
       </div>
+      {results.length > 0 && (
+        <Script
+          id='property-itemlist'
+          type='application/ld+json'
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              '@context': 'https://schema.org',
+              '@type': 'ItemList',
+              itemListElement: results.map((p, i) => ({
+                '@type': 'ListItem',
+                position: i + 1,
+                url: `/${locale}/properties/${p.id}`,
+              })),
+            }).replace(/</g, '\\u003c'),
+          }}
+        />
+      )}
     </div>
-  );
+  )
 }

--- a/scripts/section-sitemaps.js
+++ b/scripts/section-sitemaps.js
@@ -1,0 +1,35 @@
+const fs = require('fs')
+const path = require('path')
+
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://www.virintira.com'
+const locales = ['th', 'en', 'zh']
+
+function writeSitemap(file, urls) {
+  const xml = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">',
+    ...urls.map((u) => `  <url><loc>${u}</loc></url>`),
+    '</urlset>',
+  ].join('\n')
+  fs.writeFileSync(path.join(__dirname, '..', 'public', file), xml)
+}
+
+const propPath = path.join(__dirname, '..', 'public', 'data', 'properties.json')
+const properties = JSON.parse(fs.readFileSync(propPath, 'utf-8'))
+const propertyUrls = []
+for (const p of properties) {
+  for (const locale of locales) {
+    propertyUrls.push(`${siteUrl}/${locale}/properties/${p.id}`)
+  }
+}
+writeSitemap('sitemap-properties.xml', propertyUrls)
+
+const artPath = path.join(__dirname, '..', 'public', 'data', 'articles.json')
+const articles = JSON.parse(fs.readFileSync(artPath, 'utf-8'))
+const guideUrls = []
+for (const a of articles) {
+  for (const locale of Object.keys(a.locales)) {
+    guideUrls.push(`${siteUrl}/${locale}/guides/${a.slug}`)
+  }
+}
+writeSitemap('sitemap-guides.xml', guideUrls)


### PR DESCRIPTION
## Summary
- add JSON-LD schemas (WebSite, ItemList, RealEstateListing, Article) to key pages
- generate property and guide sitemaps with next-sitemap and build script
- noindex locale search page and expand robots.txt rules

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6f9ce1fdc832ba80a4cd6077f2f76