### PR TITLE
Use processed watermarked images

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+NEXT_PUBLIC_SITE_URL=https://www.virintirarealestate.com
+# Set to "true" to apply a text watermark when processing uploads
+WATERMARK_ENABLED=false

--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ NEXT_PUBLIC_SITE_URL=https://www.virintirarealestate.com
 This value is used when generating SEO metadata and the sitemap so that all
 links include an absolute URL.
 
+Set `WATERMARK_ENABLED` to `true` to apply a text watermark when processing uploads:
+
+```bash
+WATERMARK_ENABLED=true
+```
+
+When omitted or `false`, uploads are stored without a watermark.
+
+
 ## Development
 
 Start a development server with hot reload:

--- a/pages/[locale]/properties/[id].tsx
+++ b/pages/[locale]/properties/[id].tsx
@@ -5,7 +5,7 @@ import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { NextSeo } from 'next-seo'
 import Script from 'next/script'
-import PropertyImage from '@/src/components/PropertyImage'
+import PropertyImage, { ProcessedImage } from '@/src/components/PropertyImage'
 import { getSeoUrls, getLanguageAlternates } from '@/lib/seo'
 
 interface Property {
@@ -14,7 +14,7 @@ interface Property {
   type: string
   title: { en: string; th: string }
   price: number
-  images: string[]
+  images: (string | ProcessedImage)[]
 }
 
 interface Article {
@@ -90,7 +90,9 @@ export default function PropertyDetail({ property, articles }: Props) {
               price: property.price,
               priceCurrency: 'THB',
             },
-            image: property.images,
+            image: property.images.map((img) =>
+              typeof img === 'string' ? img : img.webp
+            ),
           }).replace(/</g, '\\u003c'),
         }}
       />

--- a/pages/adminmanager.tsx
+++ b/pages/adminmanager.tsx
@@ -1,0 +1,56 @@
+import { useState, FormEvent } from 'react';
+
+interface UploadResponse {
+  webp: string;
+  avif: string;
+}
+
+export default function AdminImageManager() {
+  const [result, setResult] = useState<UploadResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const form = e.currentTarget;
+    const data = new FormData(form);
+    try {
+      const res = await fetch('/api/admin/upload', {
+        method: 'POST',
+        body: data,
+      });
+      if (!res.ok) {
+        throw new Error('Upload failed');
+      }
+      const json = (await res.json()) as UploadResponse;
+      setResult(json);
+      setError(null);
+    } catch (err: any) {
+      setResult(null);
+      setError(err.message || 'Upload failed');
+    }
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-semibold">Image Manager</h1>
+      <form onSubmit={handleSubmit} className="space-y-2">
+        <input type="file" name="file" accept="image/*" required />
+        <div>
+          <button type="submit" className="px-4 py-1 border">Upload</button>
+        </div>
+      </form>
+      {error && <p className="text-red-500">{error}</p>}
+      {result && (
+        <div className="space-y-2">
+          <p>WebP URL: {result.webp}</p>
+          <p>AVIF URL: {result.avif}</p>
+          <picture>
+            <source srcSet={result.avif} type="image/avif" />
+            <source srcSet={result.webp} type="image/webp" />
+            <img src={result.webp} alt="Uploaded preview" width={300} height={200} />
+          </picture>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/pages/api/search.ts
+++ b/pages/api/search.ts
@@ -3,6 +3,7 @@ import MiniSearch from 'minisearch';
 import fs from 'fs/promises';
 import path from 'path';
 import { searchParamsSchema, type SearchParams } from '../../src/lib/validation/search';
+import type { ProcessedImage } from '../../src/components/PropertyImage';
 
 interface PropertyDTO {
   id: number;
@@ -12,7 +13,7 @@ interface PropertyDTO {
   price: number;
   priceBucket: string;
   amenities: string[];
-  images: string[];
+  images: (string | ProcessedImage)[];
   createdAt: string;
   beds?: number;
   baths?: number;

--- a/src/components/PropertyCard.tsx
+++ b/src/components/PropertyCard.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import PropertyImage from './PropertyImage';
+import PropertyImage, { ProcessedImage } from './PropertyImage';
 import { useCurrency } from '../context/CurrencyContext';
 import { formatCurrencyTHBBase } from '../lib/fx/convert';
 
@@ -7,7 +7,7 @@ interface Property {
   id: number;
   title: { en: string; th: string };
   price: number;
-  images: string[];
+  images: (string | ProcessedImage)[];
 }
 
 interface Props {
@@ -21,7 +21,7 @@ export default function PropertyCard({ property, locale }: Props) {
   const main = formatCurrencyTHBBase(property.price, currency, rates);
   const thb = formatCurrencyTHBBase(property.price, 'THB', rates);
 
-  let src: string | undefined;
+  let src: string | ProcessedImage | undefined;
   try {
     src = property.images?.[0];
   } catch {

--- a/src/components/PropertyImage.tsx
+++ b/src/components/PropertyImage.tsx
@@ -1,30 +1,52 @@
-interface Props {
-  src?: string;
-  alt: string;
+export interface ProcessedImage {
+  webp: string
+  avif: string
 }
 
-function getUrl(src?: string) {
+interface Props {
+  src?: string | ProcessedImage
+  alt: string
+}
+
+function getUrls(src?: string | ProcessedImage) {
   try {
-    if (!src) return '/images/placeholder.jpg';
-    return src.startsWith('http') ? src : `/uploads/processed/${src}`;
+    if (!src) {
+      return { img: '/images/placeholder.jpg' }
+    }
+    if (typeof src === 'string') {
+      if (src.startsWith('http')) {
+        return { img: src }
+      }
+      const base = src.replace(/\.[^/.]+$/, '')
+      return {
+        avif: `/uploads/processed/${base}.avif`,
+        webp: `/uploads/processed/${base}.webp`,
+        img: `/uploads/processed/${base}.webp`,
+      }
+    }
+    return { avif: src.avif, webp: src.webp, img: src.webp }
   } catch {
-    return '/images/placeholder.jpg';
+    return { img: '/images/placeholder.jpg' }
   }
 }
 
 export default function PropertyImage({ src, alt }: Props) {
-  const url = getUrl(src);
+  const urls = getUrls(src)
   return (
-    <img
-      src={url}
-      alt={alt}
-      width={600}
-      height={400}
-      onError={(e) => {
-        try {
-          (e.target as HTMLImageElement).src = '/images/placeholder.jpg';
-        } catch {}
-      }}
-    />
-  );
+    <picture>
+      {urls.avif && <source srcSet={urls.avif} type='image/avif' />}
+      {urls.webp && <source srcSet={urls.webp} type='image/webp' />}
+      <img
+        src={urls.img}
+        alt={alt}
+        width={600}
+        height={400}
+        onError={(e) => {
+          try {
+            (e.target as HTMLImageElement).src = '/images/placeholder.jpg'
+          } catch {}
+        }}
+      />
+    </picture>
+  )
 }

--- a/src/lib/search/indexBuilder.ts
+++ b/src/lib/search/indexBuilder.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import MiniSearch from 'minisearch';
+import type { ProcessedImage } from '@/src/components/PropertyImage';
 
 interface Property {
   id: number;
@@ -11,7 +12,7 @@ interface Property {
   price: number;
   priceBucket: string;
   amenities: string[];
-  images: string[];
+  images: (string | ProcessedImage)[];
   createdAt: string;
   updatedAt: string;
 }
@@ -52,7 +53,7 @@ export function buildIndexes() {
     price: p.price,
     priceBucket: p.priceBucket,
     amenities: p.amenities,
-    images: p.images,
+    images: p.images.map((img) => (typeof img === 'string' ? img : img.webp)),
     createdAt: p.createdAt,
   }));
 

--- a/src/workers/search.worker.ts
+++ b/src/workers/search.worker.ts
@@ -1,6 +1,7 @@
 import MiniSearch from 'minisearch';
 import { searchParamsSchema, type SearchParams } from '../lib/validation/search';
 import { MIN_PRICE, MAX_PRICE, isValidPrice } from '../lib/filters/price';
+import type { ProcessedImage } from '../components/PropertyImage';
 
 interface PropertyDTO {
   id: number;
@@ -10,7 +11,7 @@ interface PropertyDTO {
   price: number;
   priceBucket: string;
   amenities: string[];
-  images: string[];
+  images: (string | ProcessedImage)[];
   createdAt: string;
   beds?: number;
   baths?: number;


### PR DESCRIPTION
## Summary
- Add admin image manager page that uploads images and previews processed URLs
- Serve property images from watermarked processed formats with placeholder fallback
- Document WATERMARK_ENABLED environment variable for watermark processing

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7015cc0a8832b90637385e19294f7