### PR TITLE
feat: add page transition animations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "autoprefixer": "^10.4.21",
         "eslint-plugin-react": "^7.37.5",
         "formidable": "^3.5.4",
+        "framer-motion": "^12.23.12",
         "i18next": "^25.3.2",
         "minisearch": "^7.1.2",
         "negotiator": "^0.6.4",
@@ -4033,6 +4034,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.23.12",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.12.tgz",
+      "integrity": "sha512-6e78rdVtnBvlEVgu6eFEAgG9v3wLnYEboM8I5O5EXvfKC8gxGQB8wXJdhkMy10iVcn05jl6CNw7/HTsTCfwcWg==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.23.12",
+        "motion-utils": "^12.23.6",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -6203,6 +6231,21 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.1.2.tgz",
       "integrity": "sha512-R1Pd9eF+MD5JYDDSPAp/q1ougKglm14uEkPMvQ/05RGmx6G9wvmLTrTI/Q5iPNJLYqNdsDQ7qTGIcNWR+FrHmA==",
+      "license": "MIT"
+    },
+    "node_modules/motion-dom": {
+      "version": "12.23.12",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.12.tgz",
+      "integrity": "sha512-RcR4fvMCTESQBD/uKQe49D5RUeDOokkGRmz4ceaJKDBgHYtZtntC/s2vLvY38gqGaytinij/yi3hMcWVcEF5Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.23.6"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.23.6",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.23.6.tgz",
+      "integrity": "sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==",
       "license": "MIT"
     },
     "node_modules/mri": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "autoprefixer": "^10.4.21",
     "eslint-plugin-react": "^7.37.5",
     "formidable": "^3.5.4",
+    "framer-motion": "^12.23.12",
     "i18next": "^25.3.2",
     "minisearch": "^7.1.2",
     "negotiator": "^0.6.4",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -8,9 +8,58 @@ import { buildUrl } from "../lib/url";
 import defaultSeo from "../next-seo.config";
 import { CurrencyProvider } from "../src/context/CurrencyContext";
 import { prompt, inter, notoSC } from "../src/styles/fonts";
+import { useEffect, useRef, useState } from "react";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+
+function useNavDirection() {
+  const router = useRouter();
+  const [direction, setDirection] = useState<"forward" | "back">("forward");
+  const currentIndex = useRef(0);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const path = router.asPath;
+    const map = JSON.parse(sessionStorage.getItem("nav-index") || "{}");
+    if (map[path] == null) {
+      const nextIndex = Object.keys(map).length;
+      map[path] = nextIndex;
+      sessionStorage.setItem("nav-index", JSON.stringify(map));
+      currentIndex.current = nextIndex;
+    } else {
+      currentIndex.current = map[path];
+    }
+
+    const handleRouteChange = (url: string) => {
+      const stored = JSON.parse(sessionStorage.getItem("nav-index") || "{}");
+      if (stored[url] == null) {
+        const nextIndex = Object.keys(stored).length;
+        stored[url] = nextIndex;
+        sessionStorage.setItem("nav-index", JSON.stringify(stored));
+        setDirection("forward");
+        currentIndex.current = nextIndex;
+      } else {
+        const nextIndex = stored[url];
+        setDirection(nextIndex > currentIndex.current ? "forward" : "back");
+        currentIndex.current = nextIndex;
+      }
+    };
+
+    router.events.on("routeChangeStart", handleRouteChange);
+    return () => {
+      router.events.off("routeChangeStart", handleRouteChange);
+    };
+  }, [router]);
+
+  return direction;
+}
 
 function MyApp({ Component, pageProps }: AppProps) {
-  const { locale, defaultLocale } = useRouter();
+  const router = useRouter();
+  const { locale, defaultLocale } = router;
+  const direction = useNavDirection();
+  const prefersReducedMotion = useReducedMotion();
+
   const { baseUrl, siteUrl } = buildUrl(locale ?? defaultLocale);
   const orgJsonLd = {
     "@context": "https://schema.org",
@@ -31,13 +80,44 @@ function MyApp({ Component, pageProps }: AppProps) {
     url: siteUrl,
   };
 
+  const variants = {
+    forward: {
+      hidden: { x: 100, opacity: 0 },
+      enter: { x: 0, opacity: 1 },
+      exit: { x: -100, opacity: 0 },
+    },
+    back: {
+      hidden: { x: -100, opacity: 0 },
+      enter: { x: 0, opacity: 1 },
+      exit: { x: 100, opacity: 0 },
+    },
+    fade: {
+      hidden: { opacity: 0 },
+      enter: { opacity: 1 },
+      exit: { opacity: 0 },
+    },
+  } as const;
+
+  const variantKey = prefersReducedMotion ? "fade" : direction;
+
   return (
     <div className={`${prompt.variable} ${inter.variable} ${notoSC.variable}`}>
       <DefaultSeo {...defaultSeo} />
       <JsonLd scriptId="organization-jsonld" {...orgJsonLd} />
       <JsonLd scriptId="website-jsonld" {...webSiteJsonLd} />
       <CurrencyProvider>
-        <Component {...pageProps} />
+        <AnimatePresence mode="wait" initial={false}>
+          <motion.div
+            key={router.asPath}
+            variants={variants[variantKey]}
+            initial="hidden"
+            animate="enter"
+            exit="exit"
+            transition={{ type: "tween", duration: 0.2 }}
+          >
+            <Component {...pageProps} />
+          </motion.div>
+        </AnimatePresence>
       </CurrencyProvider>
     </div>
   );


### PR DESCRIPTION
## Summary
- add framer-motion for animated page transitions
- track navigation direction in _app to differentiate forward/back
- animate page changes with motion variants and reduced-motion fallback

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c785c770b0832ba00d607fe1635e9b