### PR TITLE
feat: add breadcrumbs navigation and jsonld

### DIFF
--- a/pages/[locale]/guides/[slug].tsx
+++ b/pages/[locale]/guides/[slug].tsx
@@ -6,6 +6,9 @@ import { serialize } from 'next-mdx-remote/serialize'
 import { useRouter } from 'next/router'
 import { NextSeo, ArticleJsonLd } from 'next-seo'
 import { getSeoUrls, getLanguageAlternates } from '@/lib/seo'
+import Breadcrumbs from '@/src/components/Breadcrumbs'
+import BreadcrumbJsonLd from '@/src/components/JsonLd/BreadcrumbJsonLd'
+import { guidesCrumbs } from '@/src/lib/nav/crumbs'
 
 interface ArticleData {
   slug: string
@@ -27,6 +30,7 @@ export default function GuideDetail({ source, article }: Props) {
     ? router.query.locale[0]
     : (router.query.locale as string)
   const { pageUrl } = getSeoUrls(lang, `/guides/${article.slug}`)
+  const crumbs = guidesCrumbs(lang, article.slug, article.title)
 
   return (
     <div>
@@ -36,6 +40,8 @@ export default function GuideDetail({ source, article }: Props) {
         openGraph={{ images: [{ url: article.coverImage }] }}
         languageAlternates={getLanguageAlternates(`/guides/${article.slug}`)}
       />
+      <BreadcrumbJsonLd items={crumbs} />
+      <Breadcrumbs items={crumbs} />
       <ArticleJsonLd
         url={pageUrl}
         title={article.title}

--- a/pages/[locale]/guides/index.tsx
+++ b/pages/[locale]/guides/index.tsx
@@ -8,6 +8,9 @@ import MiniSearch from 'minisearch'
 import { NextSeo } from 'next-seo'
 import Script from 'next/script'
 import { getSeoUrls, getLanguageAlternates } from '@/lib/seo'
+import Breadcrumbs from '@/src/components/Breadcrumbs'
+import BreadcrumbJsonLd from '@/src/components/JsonLd/BreadcrumbJsonLd'
+import { guidesCrumbs } from '@/src/lib/nav/crumbs'
 
 interface Article {
   slug: string
@@ -29,6 +32,7 @@ export default function GuidesList({ articles, categories }: Props) {
     ? router.query.locale[0]
     : (router.query.locale as string)
   const { pageUrl } = getSeoUrls(lang, '/guides')
+  const crumbs = guidesCrumbs(lang)
 
   const [query, setQuery] = useState('')
   const [category, setCategory] = useState('')
@@ -76,6 +80,8 @@ export default function GuidesList({ articles, categories }: Props) {
         canonical={pageUrl}
         languageAlternates={getLanguageAlternates('/guides')}
       />
+      <BreadcrumbJsonLd items={crumbs} />
+      <Breadcrumbs items={crumbs} />
       <h1>Guides</h1>
       <input
         value={query}

--- a/pages/[locale]/properties/[id].tsx
+++ b/pages/[locale]/properties/[id].tsx
@@ -7,6 +7,9 @@ import { NextSeo } from 'next-seo'
 import Script from 'next/script'
 import PropertyImage, { ProcessedImage } from '@/src/components/PropertyImage'
 import { getSeoUrls, getLanguageAlternates } from '@/lib/seo'
+import Breadcrumbs from '@/src/components/Breadcrumbs'
+import BreadcrumbJsonLd from '@/src/components/JsonLd/BreadcrumbJsonLd'
+import { pdpCrumbs } from '@/src/lib/nav/crumbs'
 
 interface Property {
   id: number
@@ -42,6 +45,7 @@ export default function PropertyDetail({ property, articles }: Props) {
     (a) => a.category === property.type || a.provinces.includes(property.province.en)
   )
   const { pageUrl } = getSeoUrls(lang, `/properties/${property.id}`)
+  const crumbs = pdpCrumbs(lang, property.id, title)
 
   return (
     <div>
@@ -50,6 +54,8 @@ export default function PropertyDetail({ property, articles }: Props) {
         canonical={pageUrl}
         languageAlternates={getLanguageAlternates(`/properties/${property.id}`)}
       />
+      <BreadcrumbJsonLd items={crumbs} />
+      <Breadcrumbs items={crumbs} />
       <div>
         {property.images.length > 0 ? (
           property.images.map((img, i) => (

--- a/pages/properties.tsx
+++ b/pages/properties.tsx
@@ -6,6 +6,9 @@ import PropertyFilters, { Filters } from '../src/components/PropertyFilters'
 import PropertyCard from '../src/components/PropertyCard'
 import { filterParamsSchema } from '../src/lib/validation/search'
 import { getLanguageAlternates, getSeoUrls } from '../lib/seo'
+import Breadcrumbs from '@/src/components/Breadcrumbs'
+import BreadcrumbJsonLd from '@/src/components/JsonLd/BreadcrumbJsonLd'
+import { listingCrumbs } from '@/src/lib/nav/crumbs'
 
 interface SearchResponse {
   total: number;
@@ -18,6 +21,7 @@ export default function PropertySearchPage() {
   const [filters, setFilters] = useState<Filters>({})
   const [results, setResults] = useState<any[]>([])
   const { pageUrl } = getSeoUrls(locale, '/properties')
+  const crumbs = listingCrumbs(locale)
 
   const runSearch = (f: Filters) => {
     const worker = new Worker(new URL('../src/workers/search.worker.ts', import.meta.url))
@@ -57,6 +61,8 @@ export default function PropertySearchPage() {
         canonical={pageUrl}
         languageAlternates={getLanguageAlternates('/properties')}
       />
+      <BreadcrumbJsonLd items={crumbs} />
+      <Breadcrumbs items={crumbs} />
       <PropertyFilters filters={filters} onChange={handleChange} />
       <div className='grid grid-cols-1 md:grid-cols-2 gap-4'>
         {results.map((p) => (

--- a/src/components/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs.tsx
@@ -1,0 +1,27 @@
+import Link from 'next/link';
+import type { Crumb } from '@/src/lib/nav/crumbs';
+
+interface Props {
+  items: Crumb[];
+}
+
+export default function Breadcrumbs({ items }: Props) {
+  return (
+    <nav aria-label="Breadcrumb">
+      <ol>
+        {items.map((item, index) => (
+          <li
+            key={item.href + index}
+            {...(index === items.length - 1 ? { 'aria-current': 'page' } : {})}
+          >
+            {index === items.length - 1 ? (
+              <span>{item.label}</span>
+            ) : (
+              <Link href={item.href}>{item.label}</Link>
+            )}
+          </li>
+        ))}
+      </ol>
+    </nav>
+  );
+}

--- a/src/components/JsonLd/BreadcrumbJsonLd.tsx
+++ b/src/components/JsonLd/BreadcrumbJsonLd.tsx
@@ -1,0 +1,21 @@
+import JsonLd from '@/components/JsonLd';
+import type { Crumb } from '@/src/lib/nav/crumbs';
+
+interface Props {
+  items: Crumb[];
+  scriptId?: string;
+}
+
+export default function BreadcrumbJsonLd({ items, scriptId = 'breadcrumbs-jsonld' }: Props) {
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: items.map((item, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      name: item.label,
+      item: item.href,
+    })),
+  };
+  return <JsonLd scriptId={scriptId} {...jsonLd} />;
+}

--- a/src/lib/nav/crumbs.ts
+++ b/src/lib/nav/crumbs.ts
@@ -1,0 +1,48 @@
+export interface Crumb {
+  href: string;
+  label: string;
+}
+
+const LABELS = {
+  en: { home: 'Home', properties: 'Properties', guides: 'Guides' },
+  th: { home: 'หน้าแรก', properties: 'อสังหา', guides: 'คู่มือ' },
+  zh: { home: '首页', properties: '房源', guides: '指南' },
+} as const;
+
+type Lang = keyof typeof LABELS;
+
+function t(locale: string) {
+  return LABELS[(locale as Lang) in LABELS ? (locale as Lang) : 'en'];
+}
+
+export function listingCrumbs(locale: string): Crumb[] {
+  const l = t(locale);
+  const base = `/${locale}`;
+  return [
+    { href: base, label: l.home },
+    { href: `${base}/properties`, label: l.properties },
+  ];
+}
+
+export function pdpCrumbs(locale: string, id: string | number, title: string): Crumb[] {
+  const l = t(locale);
+  const base = `/${locale}`;
+  return [
+    { href: base, label: l.home },
+    { href: `${base}/properties`, label: l.properties },
+    { href: `${base}/properties/${id}`, label: title },
+  ];
+}
+
+export function guidesCrumbs(locale: string, slug?: string, title?: string): Crumb[] {
+  const l = t(locale);
+  const base = `/${locale}`;
+  const crumbs: Crumb[] = [
+    { href: base, label: l.home },
+    { href: `${base}/guides`, label: l.guides },
+  ];
+  if (slug && title) {
+    crumbs.push({ href: `${base}/guides/${slug}`, label: title });
+  }
+  return crumbs;
+}


### PR DESCRIPTION
## Summary
- add Breadcrumbs component and BreadcrumbJsonLd generator
- provide locale-aware breadcrumb helpers for listing, property detail, and guides
- integrate UI breadcrumbs and JSON-LD across property and guide pages

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c78d70eda8832bb31faed1e58e34ca