### PR TITLE
refactor: extract page content components

### DIFF
--- a/pages/[locale]/guides/[slug].tsx
+++ b/pages/[locale]/guides/[slug].tsx
@@ -1,23 +1,14 @@
 import fs from 'fs'
 import path from 'path'
 import { GetStaticPaths, GetStaticProps } from 'next'
-import { MDXRemote, MDXRemoteSerializeResult } from 'next-mdx-remote'
+import { MDXRemoteSerializeResult } from 'next-mdx-remote'
 import { serialize } from 'next-mdx-remote/serialize'
 import { useRouter } from 'next/router'
 import { NextSeo, ArticleJsonLd } from 'next-seo'
 import { getSeoUrls, getLanguageAlternates } from '@/lib/seo'
-import Breadcrumbs from '@/src/components/Breadcrumbs'
 import BreadcrumbJsonLd from '@/src/components/JsonLd/BreadcrumbJsonLd'
 import { guidesCrumbs } from '@/src/lib/nav/crumbs'
-
-interface ArticleData {
-  slug: string
-  category: string
-  coverImage: string
-  publishedAt: string
-  provinces: string[]
-  title: string
-}
+import GuideDetailPageContent, { ArticleData } from '../../../../src/views/guides/GuideDetailPageContent'
 
 interface Props {
   source: MDXRemoteSerializeResult
@@ -33,7 +24,7 @@ export default function GuideDetail({ source, article }: Props) {
   const crumbs = guidesCrumbs(lang, article.slug, article.title)
 
   return (
-    <div>
+    <>
       <NextSeo
         title={article.title}
         canonical={pageUrl}
@@ -41,7 +32,6 @@ export default function GuideDetail({ source, article }: Props) {
         languageAlternates={getLanguageAlternates(`/guides/${article.slug}`)}
       />
       <BreadcrumbJsonLd items={crumbs} />
-      <Breadcrumbs items={crumbs} />
       <ArticleJsonLd
         url={pageUrl}
         title={article.title}
@@ -50,9 +40,8 @@ export default function GuideDetail({ source, article }: Props) {
         authorName={['Virintira']}
         description={article.title}
       />
-      <h1>{article.title}</h1>
-      <MDXRemote {...source} />
-    </div>
+      <GuideDetailPageContent source={source} article={article} crumbs={crumbs} />
+    </>
   )
 }
 

--- a/pages/[locale]/guides/index.tsx
+++ b/pages/[locale]/guides/index.tsx
@@ -1,25 +1,12 @@
 import fs from 'fs'
 import path from 'path'
 import { GetStaticPaths, GetStaticProps } from 'next'
-import Link from 'next/link'
 import { useRouter } from 'next/router'
-import { useEffect, useState } from 'react'
-import MiniSearch from 'minisearch'
 import { NextSeo } from 'next-seo'
-import Script from 'next/script'
 import { getSeoUrls, getLanguageAlternates } from '@/lib/seo'
-import Breadcrumbs from '@/src/components/Breadcrumbs'
 import BreadcrumbJsonLd from '@/src/components/JsonLd/BreadcrumbJsonLd'
 import { guidesCrumbs } from '@/src/lib/nav/crumbs'
-
-interface Article {
-  slug: string
-  category: string
-  coverImage: string
-  publishedAt: string
-  provinces: string[]
-  title: string
-}
+import GuidesPageContent, { Article } from '../../../src/views/guides/GuidesPageContent'
 
 interface Props {
   articles: Article[]
@@ -34,96 +21,21 @@ export default function GuidesList({ articles, categories }: Props) {
   const { pageUrl } = getSeoUrls(lang, '/guides')
   const crumbs = guidesCrumbs(lang)
 
-  const [query, setQuery] = useState('')
-  const [category, setCategory] = useState('')
-  const [mini, setMini] = useState<MiniSearch<Article> | null>(null)
-  const [results, setResults] = useState<Article[]>(articles)
-
-  useEffect(() => {
-    async function load() {
-      const res = await fetch(`/data/index/articles-${lang}.json`)
-      const json = await res.json()
-      const m = MiniSearch.loadJSON(json, {
-        idField: 'slug',
-        fields: ['title', 'category', 'provinces'],
-        storeFields: ['slug', 'title', 'category', 'provinces'],
-      }) as MiniSearch<Article>
-      setMini(m)
-    }
-    load()
-  }, [lang])
-
-  useEffect(() => {
-    if (!mini) {
-      setResults(filterCategory(articles, category))
-      return
-    }
-    if (!query) {
-      setResults(filterCategory(articles, category))
-    } else {
-      const hits = mini.search(query, { prefix: true }) as any[]
-      const slugs = new Set(hits.map((h) => h.id))
-      const filtered = articles.filter((a) => slugs.has(a.slug))
-      setResults(filterCategory(filtered, category))
-    }
-  }, [query, category, mini, articles])
-
-  function filterCategory(list: Article[], cat: string) {
-    if (!cat) return list
-    return list.filter((a) => a.category === cat)
-  }
-
   return (
-    <div>
+    <>
       <NextSeo
         title='Guides'
         canonical={pageUrl}
         languageAlternates={getLanguageAlternates('/guides')}
       />
       <BreadcrumbJsonLd items={crumbs} />
-      <Breadcrumbs items={crumbs} />
-      <h1>Guides</h1>
-      <input
-        value={query}
-        onChange={(e) => setQuery(e.target.value)}
-        placeholder='Search guides'
+      <GuidesPageContent
+        articles={articles}
+        categories={categories}
+        lang={lang}
+        crumbs={crumbs}
       />
-      <select value={category} onChange={(e) => setCategory(e.target.value)}>
-        <option value=''>All categories</option>
-        {categories.map((cat) => (
-          <option key={cat} value={cat}>
-            {cat}
-          </option>
-        ))}
-      </select>
-      <ul>
-        {results.map((a) => (
-          <li key={a.slug}>
-            <Link href={`/${lang}/guides/${a.slug}`}>
-              <img src={a.coverImage} alt='' width={100} />
-              <span>{a.title}</span>
-            </Link>
-          </li>
-        ))}
-      </ul>
-      {results.length > 0 && (
-        <Script
-          id='guides-itemlist'
-          type='application/ld+json'
-          dangerouslySetInnerHTML={{
-            __html: JSON.stringify({
-              '@context': 'https://schema.org',
-              '@type': 'ItemList',
-              itemListElement: results.map((a, i) => ({
-                '@type': 'ListItem',
-                position: i + 1,
-                url: `/${lang}/guides/${a.slug}`,
-              })),
-            }).replace(/</g, '\\u003c'),
-          }}
-        />
-      )}
-    </div>
+    </>
   )
 }
 

--- a/pages/[locale]/properties/[id].tsx
+++ b/pages/[locale]/properties/[id].tsx
@@ -1,32 +1,16 @@
 import fs from 'fs'
 import path from 'path'
 import { GetStaticPaths, GetStaticProps } from 'next'
-import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { NextSeo } from 'next-seo'
 import Script from 'next/script'
-import PropertyImage, { ProcessedImage } from '@/src/components/PropertyImage'
 import { getSeoUrls, getLanguageAlternates } from '@/lib/seo'
-import Breadcrumbs from '@/src/components/Breadcrumbs'
 import BreadcrumbJsonLd from '@/src/components/JsonLd/BreadcrumbJsonLd'
 import { pdpCrumbs } from '@/src/lib/nav/crumbs'
-
-interface Property {
-  id: number
-  province: { en: string; th: string }
-  type: string
-  title: { en: string; th: string }
-  price: number
-  images: (string | ProcessedImage)[]
-}
-
-interface Article {
-  slug: string
-  category: string
-  provinces: string[]
-  coverImage: string
-  title: string
-}
+import PropertyDetailPageContent, {
+  Property,
+  Article,
+} from '../../../../src/views/properties/PropertyDetailPageContent'
 
 interface Props {
   property: Property
@@ -41,41 +25,25 @@ export default function PropertyDetail({ property, articles }: Props) {
   const title = property.title[lang as 'en' | 'th'] || property.title.en
   const provinceName =
     property.province[lang as 'en' | 'th'] || property.province.en
-  const related = articles.filter(
-    (a) => a.category === property.type || a.provinces.includes(property.province.en)
-  )
   const { pageUrl } = getSeoUrls(lang, `/properties/${property.id}`)
   const crumbs = pdpCrumbs(lang, property.id, title)
 
   return (
-    <div>
+    <>
       <NextSeo
         title={title}
         canonical={pageUrl}
         languageAlternates={getLanguageAlternates(`/properties/${property.id}`)}
       />
       <BreadcrumbJsonLd items={crumbs} />
-      <Breadcrumbs items={crumbs} />
-      <div>
-        {property.images.length > 0 ? (
-          property.images.map((img, i) => (
-            <PropertyImage key={img + i} src={img} alt={`${title} image ${i + 1}`} />
-          ))
-        ) : (
-          <PropertyImage src={undefined} alt={`${title} placeholder`} />
-        )}
-      </div>
-      <h1>{title}</h1>
-      <p>{provinceName}</p>
-      <p>{property.price}</p>
-      <h2>Related Guides</h2>
-      <ul>
-        {related.map((a) => (
-          <li key={a.slug}>
-            <Link href={`/${lang}/guides/${a.slug}`}>{a.title}</Link>
-          </li>
-        ))}
-      </ul>
+      <PropertyDetailPageContent
+        property={property}
+        articles={articles}
+        lang={lang}
+        title={title}
+        provinceName={provinceName}
+        crumbs={crumbs}
+      />
       <Script
         id='realestate-listing'
         type='application/ld+json'
@@ -102,7 +70,7 @@ export default function PropertyDetail({ property, articles }: Props) {
           }).replace(/</g, '\\u003c'),
         }}
       />
-    </div>
+    </>
   )
 }
 

--- a/pages/[locale]/search/index.tsx
+++ b/pages/[locale]/search/index.tsx
@@ -1,6 +1,7 @@
 import { NextSeo } from 'next-seo'
 import { useRouter } from 'next/router'
 import { getSeoUrls, getLanguageAlternates } from '@/lib/seo'
+import SearchPageContent from '../../../src/views/search/SearchPageContent'
 
 export default function SearchPage() {
   const { locale, defaultLocale } = useRouter()
@@ -15,7 +16,7 @@ export default function SearchPage() {
         noindex
         languageAlternates={getLanguageAlternates('/search')}
       />
-      <h1>Search</h1>
+      <SearchPageContent />
     </>
   )
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -9,9 +9,7 @@ import {
 } from 'next-seo'
 import { useRouter } from 'next/router'
 import Script from 'next/script'
-import LanguageSwitcher from "./../components/LanguageSwitcher"
-import CurrencySwitcher from "../src/components/CurrencySwitcher"
-import PropertyPrice from "../src/components/PropertyPrice"
+import HomePageContent from '../src/views/home/HomePageContent'
 import { getOpenGraph, getLanguageAlternates, getSeoUrls } from '../lib/seo'
 
 export default function Home() {
@@ -116,11 +114,7 @@ export default function Home() {
           }).replace(/</g, '\\u003c'),
         }}
       />
-      <LanguageSwitcher />
-      <CurrencySwitcher />
-      <PropertyPrice priceTHB={1000000} />
-      <h1>{t('welcome')}</h1>
-      <p>{keywords.join(', ')}</p>
+      <HomePageContent keywords={keywords} />
     </>
   )
 }

--- a/src/views/guides/GuideDetailPageContent.tsx
+++ b/src/views/guides/GuideDetailPageContent.tsx
@@ -1,0 +1,28 @@
+import { MDXRemote, MDXRemoteSerializeResult } from 'next-mdx-remote'
+import Breadcrumbs from '../../components/Breadcrumbs'
+import { Crumb } from '../../lib/nav/crumbs'
+
+export interface ArticleData {
+  slug: string
+  category: string
+  coverImage: string
+  publishedAt: string
+  provinces: string[]
+  title: string
+}
+
+interface Props {
+  source: MDXRemoteSerializeResult
+  article: ArticleData
+  crumbs: Crumb[]
+}
+
+export default function GuideDetailPageContent({ source, article, crumbs }: Props) {
+  return (
+    <div>
+      <Breadcrumbs items={crumbs} />
+      <h1>{article.title}</h1>
+      <MDXRemote {...source} />
+    </div>
+  )
+}

--- a/src/views/guides/GuidesPageContent.tsx
+++ b/src/views/guides/GuidesPageContent.tsx
@@ -1,0 +1,110 @@
+import Link from 'next/link'
+import { useEffect, useState } from 'react'
+import MiniSearch from 'minisearch'
+import Script from 'next/script'
+import Breadcrumbs from '../../components/Breadcrumbs'
+import { Crumb } from '../../lib/nav/crumbs'
+
+export interface Article {
+  slug: string
+  category: string
+  coverImage: string
+  publishedAt: string
+  provinces: string[]
+  title: string
+}
+
+interface Props {
+  articles: Article[]
+  categories: string[]
+  lang: string
+  crumbs: Crumb[]
+}
+
+export default function GuidesPageContent({ articles, categories, lang, crumbs }: Props) {
+  const [query, setQuery] = useState('')
+  const [category, setCategory] = useState('')
+  const [mini, setMini] = useState<MiniSearch<Article> | null>(null)
+  const [results, setResults] = useState<Article[]>(articles)
+
+  useEffect(() => {
+    async function load() {
+      const res = await fetch(`/data/index/articles-${lang}.json`)
+      const json = await res.json()
+      const m = MiniSearch.loadJSON(json, {
+        idField: 'slug',
+        fields: ['title', 'category', 'provinces'],
+        storeFields: ['slug', 'title', 'category', 'provinces'],
+      }) as MiniSearch<Article>
+      setMini(m)
+    }
+    load()
+  }, [lang])
+
+  useEffect(() => {
+    if (!mini) {
+      setResults(filterCategory(articles, category))
+      return
+    }
+    if (!query) {
+      setResults(filterCategory(articles, category))
+    } else {
+      const hits = mini.search(query, { prefix: true }) as any[]
+      const slugs = new Set(hits.map((h) => h.id))
+      const filtered = articles.filter((a) => slugs.has(a.slug))
+      setResults(filterCategory(filtered, category))
+    }
+  }, [query, category, mini, articles])
+
+  function filterCategory(list: Article[], cat: string) {
+    if (!cat) return list
+    return list.filter((a) => a.category === cat)
+  }
+
+  return (
+    <div>
+      <Breadcrumbs items={crumbs} />
+      <h1>Guides</h1>
+      <input
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder='Search guides'
+      />
+      <select value={category} onChange={(e) => setCategory(e.target.value)}>
+        <option value=''>All categories</option>
+        {categories.map((cat) => (
+          <option key={cat} value={cat}>
+            {cat}
+          </option>
+        ))}
+      </select>
+      <ul>
+        {results.map((a) => (
+          <li key={a.slug}>
+            <Link href={`/${lang}/guides/${a.slug}`}>
+              <img src={a.coverImage} alt='' width={100} />
+              <span>{a.title}</span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+      {results.length > 0 && (
+        <Script
+          id='guides-itemlist'
+          type='application/ld+json'
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              '@context': 'https://schema.org',
+              '@type': 'ItemList',
+              itemListElement: results.map((a, i) => ({
+                '@type': 'ListItem',
+                position: i + 1,
+                url: `/${lang}/guides/${a.slug}`,
+              })),
+            }).replace(/</g, '\\u003c'),
+          }}
+        />
+      )}
+    </div>
+  )
+}

--- a/src/views/home/HomePageContent.tsx
+++ b/src/views/home/HomePageContent.tsx
@@ -1,0 +1,21 @@
+import LanguageSwitcher from '../../../components/LanguageSwitcher'
+import CurrencySwitcher from '../../components/CurrencySwitcher'
+import PropertyPrice from '../../components/PropertyPrice'
+import { useTranslation } from 'next-i18next'
+
+interface Props {
+  keywords: string[]
+}
+
+export default function HomePageContent({ keywords }: Props) {
+  const { t } = useTranslation('common')
+  return (
+    <>
+      <LanguageSwitcher />
+      <CurrencySwitcher />
+      <PropertyPrice priceTHB={1000000} />
+      <h1>{t('welcome')}</h1>
+      <p>{keywords.join(', ')}</p>
+    </>
+  )
+}

--- a/src/views/properties/PropertyDetailPageContent.tsx
+++ b/src/views/properties/PropertyDetailPageContent.tsx
@@ -1,0 +1,69 @@
+import Link from 'next/link'
+import PropertyImage, { ProcessedImage } from '../../components/PropertyImage'
+import Breadcrumbs from '../../components/Breadcrumbs'
+import { Crumb } from '../../lib/nav/crumbs'
+
+export interface Property {
+  id: number
+  province: { en: string; th: string }
+  type: string
+  title: { en: string; th: string }
+  price: number
+  images: (string | ProcessedImage)[]
+}
+
+export interface Article {
+  slug: string
+  category: string
+  provinces: string[]
+  coverImage: string
+  title: string
+}
+
+interface Props {
+  property: Property
+  articles: Article[]
+  lang: string
+  title: string
+  provinceName: string
+  crumbs: Crumb[]
+}
+
+export default function PropertyDetailPageContent({
+  property,
+  articles,
+  lang,
+  title,
+  provinceName,
+  crumbs,
+}: Props) {
+  const related = articles.filter(
+    (a) => a.category === property.type || a.provinces.includes(property.province.en)
+  )
+
+  return (
+    <div>
+      <Breadcrumbs items={crumbs} />
+      <div>
+        {property.images.length > 0 ? (
+          property.images.map((img, i) => (
+            <PropertyImage key={typeof img === 'string' ? img : img.webp + i} src={img} alt={`${title} image ${i + 1}`} />
+          ))
+        ) : (
+          <PropertyImage src={undefined} alt={`${title} placeholder`} />
+        )}
+      </div>
+      <h1>{title}</h1>
+      <p>{provinceName}</p>
+      <p>{property.price}</p>
+      <h2>Related Guides</h2>
+      <ul>
+        {related.map((a) => (
+          <li key={a.slug}>
+            <Link href={`/${lang}/guides/${a.slug}`}>{a.title}</Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/src/views/search/SearchPageContent.tsx
+++ b/src/views/search/SearchPageContent.tsx
@@ -1,0 +1,3 @@
+export default function SearchPageContent() {
+  return <h1>Search</h1>
+}


### PR DESCRIPTION
## Summary
- move home page view into `src/views/home/HomePageContent.tsx`
- add view components for guides, properties, and search pages
- slim page files to SEO metadata plus their content components

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c78f9ece10832bbf1d458537850129