### PR TITLE
feat: add accessible navigation components

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,0 +1,22 @@
+import Link from 'next/link'
+import { NAV_MAIN } from '@/src/config/nav'
+import LanguageSwitcher from './LanguageSwitcher'
+import CurrencySwitcher from '@/src/components/CurrencySwitcher'
+
+export default function Footer() {
+  return (
+    <footer className="mt-8 border-t pt-4">
+      <nav aria-label="Footer navigation">
+        <ul className="flex flex-wrap gap-4 items-center">
+          {NAV_MAIN.map((item) => (
+            <li key={item.title}>
+              <Link href={item.href ?? '#'}>{item.title}</Link>
+            </li>
+          ))}
+          <li><LanguageSwitcher /></li>
+          <li><CurrencySwitcher /></li>
+        </ul>
+      </nav>
+    </footer>
+  )
+}

--- a/components/Header/NavBar.tsx
+++ b/components/Header/NavBar.tsx
@@ -1,0 +1,50 @@
+import { useState, useRef } from 'react'
+import Link from 'next/link'
+import { NAV_MAIN } from '@/src/config/nav'
+import LanguageSwitcher from '../LanguageSwitcher'
+import CurrencySwitcher from '@/src/components/CurrencySwitcher'
+import MegaMenu from '../MegaMenu'
+import MobileMenu from '../MobileMenu'
+
+export default function NavBar() {
+  const [mobileOpen, setMobileOpen] = useState(false)
+  const toggleRef = useRef<HTMLButtonElement>(null)
+
+  function handleClose() {
+    setMobileOpen(false)
+    toggleRef.current?.focus()
+  }
+
+  return (
+    <header>
+      <nav aria-label="Main navigation" className="flex items-center justify-between py-4">
+        <button
+          ref={toggleRef}
+          className="md:hidden p-2"
+          aria-controls="mobile-menu"
+          aria-expanded={mobileOpen}
+          onClick={() => setMobileOpen((o) => !o)}
+        >
+          Menu
+        </button>
+        <ul className="hidden md:flex gap-4 items-center">
+          {NAV_MAIN.map((item) => (
+            <li key={item.title}>
+              {item.children ? (
+                <MegaMenu item={item} />
+              ) : (
+                <Link href={item.href ?? '#'}>{item.title}</Link>
+              )}
+            </li>
+          ))}
+          <li><LanguageSwitcher /></li>
+          <li><CurrencySwitcher /></li>
+        </ul>
+      </nav>
+      <MobileMenu open={mobileOpen} onClose={handleClose} items={NAV_MAIN}>
+        <LanguageSwitcher />
+        <CurrencySwitcher />
+      </MobileMenu>
+    </header>
+  )
+}

--- a/components/MegaMenu.tsx
+++ b/components/MegaMenu.tsx
@@ -1,0 +1,60 @@
+import { useState, useRef, useEffect } from 'react'
+import Link from 'next/link'
+import { NavItem } from '@/src/config/nav'
+
+interface MegaMenuProps {
+  item: NavItem
+}
+
+export default function MegaMenu({ item }: MegaMenuProps) {
+  const [open, setOpen] = useState(false)
+  const buttonRef = useRef<HTMLButtonElement>(null)
+  const menuRef = useRef<HTMLUListElement>(null)
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        setOpen(false)
+        buttonRef.current?.focus()
+      }
+    }
+    if (open) document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [open])
+
+  useEffect(() => {
+    if (open) menuRef.current?.querySelector('a')?.focus()
+  }, [open])
+
+  const prefersReduced =
+    typeof window !== 'undefined' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches
+
+  return (
+    <div className="relative">
+      <button
+        ref={buttonRef}
+        aria-haspopup="true"
+        aria-expanded={open}
+        onClick={() => setOpen(!open)}
+      >
+        {item.title}
+      </button>
+      {open && (
+        <ul
+          ref={menuRef}
+          role="menu"
+          className={`absolute mt-2 bg-white shadow ${prefersReduced ? '' : 'transition-opacity duration-200'}`}
+        >
+          {item.children?.map((child) => (
+            <li key={child.title} role="none">
+              <Link role="menuitem" href={child.href ?? '#'} className="block px-4 py-2">
+                {child.title}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/components/MobileMenu.tsx
+++ b/components/MobileMenu.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useRef } from 'react'
+import Link from 'next/link'
+import { NavItem } from '@/src/config/nav'
+
+interface MobileMenuProps {
+  open: boolean
+  onClose: () => void
+  items: NavItem[]
+  children?: React.ReactNode
+}
+
+export default function MobileMenu({ open, onClose, items, children }: MobileMenuProps) {
+  const menuRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        onClose()
+      }
+    }
+    if (open) document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [open, onClose])
+
+  useEffect(() => {
+    if (open) {
+      menuRef.current?.querySelector('a,button,select')?.focus()
+    }
+  }, [open])
+
+  if (!open) return null
+
+  const prefersReduced =
+    typeof window !== 'undefined' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches
+
+  return (
+    <div
+      id="mobile-menu"
+      ref={menuRef}
+      role="dialog"
+      aria-modal="true"
+      className={`md:hidden fixed inset-0 bg-white p-4 overflow-auto ${prefersReduced ? '' : 'transition-transform duration-200'}`}
+    >
+      <button onClick={onClose} className="mb-4">
+        Close
+      </button>
+      <ul className="flex flex-col gap-4" role="menu">
+        {items.map((item) => (
+          <li key={item.title} role="none">
+            <Link href={item.href ?? '#'} role="menuitem" className="block">
+              {item.title}
+            </Link>
+            {item.children && (
+              <ul className="ml-4 mt-2 flex flex-col gap-2" role="menu">
+                {item.children.map((child) => (
+                  <li key={child.title} role="none">
+                    <Link href={child.href ?? '#'} role="menuitem" className="block">
+                      {child.title}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </li>
+        ))}
+        {children && <li role="none" className="mt-4 flex gap-4 items-center">{children}</li>}
+      </ul>
+    </div>
+  )
+}

--- a/src/config/nav.ts
+++ b/src/config/nav.ts
@@ -1,0 +1,17 @@
+export interface NavItem {
+  title: string
+  href?: string
+  children?: NavItem[]
+}
+
+export const NAV_MAIN: NavItem[] = [
+  { title: 'Home', href: '/' },
+  {
+    title: 'Properties',
+    children: [
+      { title: 'Buy', href: '/buy' },
+      { title: 'Rent', href: '/rent' },
+    ],
+  },
+  { title: 'Contact', href: '/contact' },
+]


### PR DESCRIPTION
## Summary
- add nav config with typed structure
- implement NavBar with mega and mobile menus
- expose locale and currency switchers in header and footer

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c79631a9c8832ba728e2eb09ee6fb9