### PR TITLE
Rename package and isolate rate update script

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ npm run postbuild
 Refresh currency conversion data used by the site:
 
 ```bash
-npm run update-rates
+npm run update:rates
 ```
 
 This script downloads the latest daily rates from the European Central Bank

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "multi-lang-virintira",
+  "name": "virintirarealestate",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "multi-lang-virintira",
+      "name": "virintirarealestate",
       "version": "0.1.0",
       "dependencies": {
         "autoprefixer": "^10.4.21",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "multi-lang-virintira",
+  "name": "virintirarealestate",
   "version": "0.1.0",
   "private": true,
   "scripts": {
@@ -9,7 +9,7 @@
     "test": "node --test",
     "lint": "next lint",
     "postbuild": "next-sitemap && node scripts/section-sitemaps.js",
-    "update-rates": "ts-node --compiler-options '{\"module\":\"CommonJS\"}' src/lib/fx/updateRates.ts",
+    "update:rates": "ts-node --compiler-options '{\"module\":\"CommonJS\"}' scripts/update-rates.ts",
     "i18n:check": "ts-node scripts/i18n-check.ts || echo 'i18n check: warned'"
   },
   "dependencies": {

--- a/scripts/update-rates.ts
+++ b/scripts/update-rates.ts
@@ -1,0 +1,3 @@
+import { updateRates } from '../src/lib/fx/updateRates';
+
+updateRates();

--- a/src/lib/fx/updateRates.ts
+++ b/src/lib/fx/updateRates.ts
@@ -34,7 +34,3 @@ export async function updateRates(): Promise<void> {
     console.warn('Skipping rate update:', err);
   }
 }
-
-updateRates();
-
-export default updateRates;


### PR DESCRIPTION
## Summary
- rename package to `virintirarealestate`
- make FX rate updater callable via `npm run update:rates`
- export `updateRates` without executing on import

## Testing
- `npm test`
- `npm run lint`
- `npm run update:rates` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c79a485210832b8981ed95a5dd227d