### PR TITLE
chore: normalize property image sources

### DIFF
--- a/pages/[locale]/properties/[id].tsx
+++ b/pages/[locale]/properties/[id].tsx
@@ -12,6 +12,11 @@ import PropertyDetailPageContent, {
   Article,
 } from '../../../../src/views/properties/PropertyDetailPageContent'
 
+export type ImgLike = string | { src: string }
+
+export const asSrc = (img: ImgLike): string =>
+  typeof img === 'string' ? img : img.src
+
 interface Props {
   property: Property
   articles: Article[]
@@ -64,9 +69,7 @@ export default function PropertyDetail({ property, articles }: Props) {
               price: property.price,
               priceCurrency: 'THB',
             },
-            image: property.images.map((img) =>
-              typeof img === 'string' ? img : img.webp
-            ),
+            image: (property.images ?? []).map(asSrc),
           }).replace(/</g, '\\u003c'),
         }}
       />

--- a/src/components/PropertyCard.tsx
+++ b/src/components/PropertyCard.tsx
@@ -1,13 +1,18 @@
 import Link from 'next/link';
-import PropertyImage, { ProcessedImage } from './PropertyImage';
+import PropertyImage from './PropertyImage';
 import { useCurrency } from '../context/CurrencyContext';
 import { formatCurrencyTHBBase } from '../lib/fx/convert';
+
+type ImgLike = string | { src: string };
+
+const asSrc = (img?: ImgLike): string | undefined =>
+  typeof img === 'string' ? img : img?.src;
 
 interface Property {
   id: number;
   title: { en: string; th: string };
   price: number;
-  images: (string | ProcessedImage)[];
+  images: ImgLike[];
 }
 
 interface Props {
@@ -21,12 +26,7 @@ export default function PropertyCard({ property, locale }: Props) {
   const main = formatCurrencyTHBBase(property.price, currency, rates);
   const thb = formatCurrencyTHBBase(property.price, 'THB', rates);
 
-  let src: string | ProcessedImage | undefined;
-  try {
-    src = property.images?.[0];
-  } catch {
-    src = undefined;
-  }
+  const src = asSrc(property.images?.[0]);
 
   return (
     <div className="border p-2">

--- a/src/components/PropertyImage.tsx
+++ b/src/components/PropertyImage.tsx
@@ -4,49 +4,23 @@ export interface ProcessedImage {
 }
 
 interface Props {
-  src?: string | ProcessedImage
+  src?: string
   alt: string
 }
 
-function getUrls(src?: string | ProcessedImage) {
-  try {
-    if (!src) {
-      return { img: '/images/placeholder.jpg' }
-    }
-    if (typeof src === 'string') {
-      if (src.startsWith('http')) {
-        return { img: src }
-      }
-      const base = src.replace(/\.[^/.]+$/, '')
-      return {
-        avif: `/uploads/processed/${base}.avif`,
-        webp: `/uploads/processed/${base}.webp`,
-        img: `/uploads/processed/${base}.webp`,
-      }
-    }
-    return { avif: src.avif, webp: src.webp, img: src.webp }
-  } catch {
-    return { img: '/images/placeholder.jpg' }
-  }
-}
-
 export default function PropertyImage({ src, alt }: Props) {
-  const urls = getUrls(src)
+  const finalSrc = src || '/images/placeholder.jpg'
   return (
-    <picture>
-      {urls.avif && <source srcSet={urls.avif} type='image/avif' />}
-      {urls.webp && <source srcSet={urls.webp} type='image/webp' />}
-      <img
-        src={urls.img}
-        alt={alt}
-        width={600}
-        height={400}
-        onError={(e) => {
-          try {
-            (e.target as HTMLImageElement).src = '/images/placeholder.jpg'
-          } catch {}
-        }}
-      />
-    </picture>
+    <img
+      src={finalSrc}
+      alt={alt}
+      width={600}
+      height={400}
+      onError={(e) => {
+        try {
+          ;(e.target as HTMLImageElement).src = '/images/placeholder.jpg'
+        } catch {}
+      }}
+    />
   )
 }

--- a/src/views/properties/PropertyDetailPageContent.tsx
+++ b/src/views/properties/PropertyDetailPageContent.tsx
@@ -1,7 +1,12 @@
 import Link from 'next/link'
-import PropertyImage, { ProcessedImage } from '../../components/PropertyImage'
+import PropertyImage from '../../components/PropertyImage'
 import Breadcrumbs from '../../components/Breadcrumbs'
 import { Crumb } from '../../lib/nav/crumbs'
+
+type ImgLike = string | { src: string }
+
+const asSrc = (img: ImgLike): string =>
+  typeof img === 'string' ? img : img.src
 
 export interface Property {
   id: number
@@ -9,7 +14,7 @@ export interface Property {
   type: string
   title: { en: string; th: string }
   price: number
-  images: (string | ProcessedImage)[]
+  images: ImgLike[]
 }
 
 export interface Article {
@@ -45,9 +50,13 @@ export default function PropertyDetailPageContent({
     <div>
       <Breadcrumbs items={crumbs} />
       <div>
-        {property.images.length > 0 ? (
-          property.images.map((img, i) => (
-            <PropertyImage key={typeof img === 'string' ? img : img.webp + i} src={img} alt={`${title} image ${i + 1}`} />
+        {(property.images ?? []).length > 0 ? (
+          (property.images ?? []).map((img, i) => (
+            <PropertyImage
+              key={`${asSrc(img)}-${i}`}
+              src={asSrc(img)}
+              alt={`${title} image ${i + 1}`}
+            />
           ))
         ) : (
           <PropertyImage src={undefined} alt={`${title} placeholder`} />


### PR DESCRIPTION
## Summary
- handle property images that are strings or objects by introducing `ImgLike` and `asSrc`
- render property galleries with normalized image sources
- simplify `PropertyImage` to accept plain strings and fallback to a placeholder

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c79dc125bc832bb7b4711ceccf9063