### PR TITLE
feat: add admin property quick add

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "next lint",
     "postbuild": "next-sitemap && node scripts/section-sitemaps.js",
     "update:rates": "ts-node --compiler-options '{\"module\":\"CommonJS\"}' scripts/update-rates.ts",
-    "i18n:check": "ts-node scripts/i18n-check.ts || echo 'i18n check: warned'"
+    "i18n:check": "ts-node scripts/i18n-check.ts || echo 'i18n check: warned'",
+    "index:build": "ts-node --compiler-options '{\"module\":\"CommonJS\"}' src/lib/search/indexBuilder.ts"
   },
   "dependencies": {
     "autoprefixer": "^10.4.21",

--- a/pages/adminmanager/properties.tsx
+++ b/pages/adminmanager/properties.tsx
@@ -1,0 +1,112 @@
+import { useState, FormEvent } from 'react';
+
+interface FormState {
+  type: string;
+  province: string;
+  district: string;
+  priceTHB: string;
+  beds: string;
+  baths: string;
+  areaBuilt: string;
+}
+
+export default function AdminPropertyManager() {
+  const [form, setForm] = useState<FormState>({
+    type: 'condo',
+    province: '',
+    district: '',
+    priceTHB: '',
+    beds: '',
+    baths: '',
+    areaBuilt: '',
+  });
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    const { name, value } = e.target;
+    setForm((f) => ({ ...f, [name]: value }));
+  };
+
+  const handlePublish = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    try {
+      const res = await fetch('/api/admin/properties', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          ...form,
+          priceTHB: Number(form.priceTHB),
+          beds: form.beds ? Number(form.beds) : undefined,
+          baths: form.baths ? Number(form.baths) : undefined,
+          areaBuilt: Number(form.areaBuilt),
+        }),
+      });
+      if (!res.ok) throw new Error('Publish failed');
+      alert('Property published and index built');
+      setForm({ type: 'condo', province: '', district: '', priceTHB: '', beds: '', baths: '', areaBuilt: '' });
+    } catch (err: any) {
+      alert(err.message || 'Publish failed');
+    }
+  };
+
+  const handleDemo = async () => {
+    try {
+      const res = await fetch('/api/admin/generate-demo', { method: 'POST' });
+      if (!res.ok) throw new Error('Demo generation failed');
+      if (window.confirm('Demo properties generated. Publish index now?')) {
+        const r = await fetch('/api/admin/build-index', { method: 'POST' });
+        if (!r.ok) throw new Error('Index build failed');
+        alert('Index built');
+      }
+    } catch (err: any) {
+      alert(err.message || 'Operation failed');
+    }
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-semibold">Quick Add Property</h1>
+      <form onSubmit={handlePublish} className="space-y-2">
+        <div>
+          <label className="block">Type</label>
+          <select name="type" value={form.type} onChange={handleChange} className="border p-1" required>
+            <option value="condo">Condo</option>
+            <option value="house">House</option>
+            <option value="land">Land</option>
+            <option value="townhouse">Townhouse</option>
+          </select>
+        </div>
+        <div>
+          <label className="block">Province</label>
+          <input name="province" value={form.province} onChange={handleChange} className="border p-1" required />
+        </div>
+        <div>
+          <label className="block">District</label>
+          <input name="district" value={form.district} onChange={handleChange} className="border p-1" required />
+        </div>
+        <div>
+          <label className="block">Price (THB)</label>
+          <input type="number" name="priceTHB" value={form.priceTHB} onChange={handleChange} className="border p-1" required />
+        </div>
+        <div>
+          <label className="block">Beds</label>
+          <input type="number" name="beds" value={form.beds} onChange={handleChange} className="border p-1" />
+        </div>
+        <div>
+          <label className="block">Baths</label>
+          <input type="number" name="baths" value={form.baths} onChange={handleChange} className="border p-1" />
+        </div>
+        <div>
+          <label className="block">Area Built (sqm)</label>
+          <input type="number" name="areaBuilt" value={form.areaBuilt} onChange={handleChange} className="border p-1" required />
+        </div>
+        <button type="submit" className="px-4 py-1 border">Publish</button>
+      </form>
+      {process.env.NODE_ENV !== 'production' && (
+        <div>
+          <button onClick={handleDemo} className="px-4 py-1 border">Generate Demo</button>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/pages/api/admin/build-index.ts
+++ b/pages/api/admin/build-index.ts
@@ -1,0 +1,12 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { buildIndexes } from '../../../src/lib/search/indexBuilder';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+  await buildIndexes();
+  res.status(200).json({ ok: true });
+}
+

--- a/pages/api/admin/generate-demo.ts
+++ b/pages/api/admin/generate-demo.ts
@@ -1,0 +1,77 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import fs from 'fs/promises';
+import path from 'path';
+
+function slugify(value: string) {
+  return value.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
+}
+
+function priceBucket(price: number) {
+  if (price < 1_000_000) return '0-1M';
+  if (price < 3_000_000) return '1-3M';
+  if (price < 5_000_000) return '3-5M';
+  if (price < 10_000_000) return '5-10M';
+  return '10M+';
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+  if (process.env.NODE_ENV === 'production') {
+    res.status(403).json({ error: 'Not available in production' });
+    return;
+  }
+
+  const dataPath = path.join(process.cwd(), 'public', 'data', 'properties.json');
+  let properties: any[] = [];
+  try {
+    const file = await fs.readFile(dataPath, 'utf-8');
+    properties = JSON.parse(file);
+  } catch {}
+
+  let id = properties.reduce((m, p) => Math.max(m, p.id), 0) + 1;
+  const types = ['condo', 'house', 'land'];
+  const provinces = ['Bangkok', 'Phuket', 'Chiang Mai'];
+  const now = new Date().toISOString();
+  const added: any[] = [];
+
+  for (let i = 0; i < types.length; i++) {
+    const type = types[i];
+    const province = provinces[i % provinces.length];
+    const district = 'Central';
+    const price = 1_000_000 + i * 500_000;
+    const areaBuilt = 100 + i * 20;
+    const code = `P${String(id).padStart(5, '0')}`;
+    const title = `${type} in ${province}`;
+    const prop = {
+      id,
+      slug: `${slugify(province)}-${slugify(type)}-${code.toLowerCase()}`,
+      code,
+      province: { en: province, th: province },
+      district: { en: district, th: district },
+      type,
+      title: { en: title, th: title },
+      description: { en: title, th: title },
+      price,
+      priceBucket: priceBucket(price),
+      pricePerSqm: Math.round(price / areaBuilt),
+      beds: i + 1,
+      baths: i + 1,
+      areaBuilt,
+      status: 'available',
+      amenities: [],
+      images: [{ src: `https://placehold.co/600x400?text=${encodeURIComponent(type + ' ' + code)}`, alt: title }],
+      createdAt: now,
+      updatedAt: now,
+    };
+    properties.push(prop);
+    added.push(prop);
+    id++;
+  }
+
+  await fs.writeFile(dataPath, JSON.stringify(properties, null, 2));
+  res.status(200).json({ added: added.length });
+}
+

--- a/pages/api/admin/properties.ts
+++ b/pages/api/admin/properties.ts
@@ -1,0 +1,85 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import fs from 'fs/promises';
+import path from 'path';
+import { buildIndexes } from '../../../src/lib/search/indexBuilder';
+
+interface RequestBody {
+  type: string;
+  province: string;
+  district: string;
+  priceTHB: number;
+  beds?: number;
+  baths?: number;
+  areaBuilt: number;
+}
+
+function slugify(value: string) {
+  return value.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
+}
+
+function priceBucket(price: number) {
+  if (price < 1_000_000) return '0-1M';
+  if (price < 3_000_000) return '1-3M';
+  if (price < 5_000_000) return '3-5M';
+  if (price < 10_000_000) return '5-10M';
+  return '10M+';
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+  const body: RequestBody = req.body;
+  if (!body || !body.type || !body.province || !body.district || !body.priceTHB || !body.areaBuilt) {
+    res.status(400).json({ error: 'Missing fields' });
+    return;
+  }
+
+  const dataPath = path.join(process.cwd(), 'public', 'data', 'properties.json');
+  let properties: any[] = [];
+  try {
+    const file = await fs.readFile(dataPath, 'utf-8');
+    properties = JSON.parse(file);
+  } catch {}
+
+  const id = properties.reduce((m, p) => Math.max(m, p.id), 0) + 1;
+  const code = `P${String(id).padStart(5, '0')}`;
+  const title = `${body.type} in ${body.province}`;
+  const slug = `${slugify(body.province)}-${slugify(body.type)}-${code.toLowerCase()}`;
+  const price = Number(body.priceTHB);
+  const area = Number(body.areaBuilt);
+  const pricePerSqm = area > 0 ? Math.round(price / area) : price;
+  const now = new Date().toISOString();
+  const imageUrl = `https://placehold.co/600x400?text=${encodeURIComponent(body.type + ' ' + code)}`;
+
+  const property = {
+    id,
+    slug,
+    code,
+    province: { en: body.province, th: body.province },
+    district: { en: body.district, th: body.district },
+    type: body.type,
+    title: { en: title, th: title },
+    description: { en: title, th: title },
+    price,
+    priceBucket: priceBucket(price),
+    pricePerSqm,
+    beds: body.beds,
+    baths: body.baths,
+    areaBuilt: area,
+    status: 'available',
+    amenities: [],
+    images: [{ src: imageUrl, alt: title }],
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  properties.push(property);
+  await fs.writeFile(dataPath, JSON.stringify(properties, null, 2));
+
+  await buildIndexes();
+
+  res.status(200).json({ property });
+}
+

--- a/src/lib/search/indexBuilder.ts
+++ b/src/lib/search/indexBuilder.ts
@@ -6,15 +6,21 @@ import type { ProcessedImage } from '@/src/components/PropertyImage';
 interface Property {
   id: number;
   province: { en: string; th: string };
+  district?: { en: string; th: string };
   type: string;
   title: { en: string; th: string };
   description: { en: string; th: string };
   price: number;
   priceBucket: string;
   amenities: string[];
-  images: (string | ProcessedImage)[];
+  images: (string | ProcessedImage | { src: string; alt?: string })[];
   createdAt: string;
   updatedAt: string;
+  beds?: number;
+  baths?: number;
+  areaBuilt?: number;
+  pricePerSqm?: number;
+  status?: string;
 }
 
 interface Doc {
@@ -31,6 +37,11 @@ interface Doc {
   amenities: string[];
   images: string[];
   createdAt: string;
+  beds?: number;
+  baths?: number;
+  status?: string;
+  pricePerSqm?: number;
+  areaBuilt?: number;
 }
 
 function slug(value: string) {
@@ -53,8 +64,19 @@ export function buildIndexes() {
     price: p.price,
     priceBucket: p.priceBucket,
     amenities: p.amenities,
-    images: p.images.map((img) => (typeof img === 'string' ? img : img.webp)),
+    images: p.images.map((img) =>
+      typeof img === 'string'
+        ? img
+        : 'webp' in img
+        ? (img as ProcessedImage).webp
+        : (img as any).src
+    ),
     createdAt: p.createdAt,
+    beds: p.beds,
+    baths: p.baths,
+    status: p.status,
+    pricePerSqm: p.pricePerSqm,
+    areaBuilt: p.areaBuilt,
   }));
 
   const indexDir = path.join(process.cwd(), 'public', 'data', 'index');
@@ -76,7 +98,24 @@ export function buildIndexes() {
   for (const [key, groupDocs] of groups.entries()) {
     const mini = new MiniSearch<Doc>({
       fields: ['title_en', 'title_th', 'description_en', 'description_th'],
-      storeFields: ['id', 'title_en', 'title_th', 'province', 'province_th', 'type', 'price', 'priceBucket', 'amenities', 'images', 'createdAt'],
+      storeFields: [
+        'id',
+        'title_en',
+        'title_th',
+        'province',
+        'province_th',
+        'type',
+        'price',
+        'priceBucket',
+        'amenities',
+        'images',
+        'createdAt',
+        'beds',
+        'baths',
+        'status',
+        'pricePerSqm',
+        'areaBuilt',
+      ],
     });
     mini.addAll(groupDocs);
     fs.writeFileSync(path.join(indexDir, `${key}.json`), JSON.stringify(mini.toJSON()));


### PR DESCRIPTION
## Summary
- add property management page with quick add form and demo generator
- derive property metadata and rebuild search indexes via API
- expand index builder and npm script for index building

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c79f48ef78832bbfbd7026cc946471