### PR TITLE
Rebrand to Zomzom Property and update contact defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
-NEXT_PUBLIC_SITE_URL=https://www.virintirarealestate.com
+NEXT_PUBLIC_SITE_URL=https://www.zomzomproperty.com
 # Set to "true" to apply a text watermark when processing uploads
 WATERMARK_ENABLED=false

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# virintirarealestate
+# Zomzom Property
 
 A small Next.js 14 project that demonstrates a bilingual web site using `next-i18next`.
 
@@ -22,7 +22,7 @@ or `npm run lint`. These scripts require all dependencies to be installed.
 Set `NEXT_PUBLIC_SITE_URL` to the fully qualified URL of your deployed site:
 
 ```bash
-NEXT_PUBLIC_SITE_URL=https://www.virintirarealestate.com
+NEXT_PUBLIC_SITE_URL=https://www.zomzomproperty.com
 ```
 
 This value is used when generating SEO metadata and the sitemap so that all

--- a/next-seo.config.js
+++ b/next-seo.config.js
@@ -1,11 +1,12 @@
 // next-seo.config.js
 // Default SEO configuration shared across all pages.
 // Individual pages should extend these options via the `NextSeo` component.
-const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://www.virintira.com/';
+const siteUrl =
+  process.env.NEXT_PUBLIC_SITE_URL || 'https://www.zomzomproperty.com/';
 
 const config = {
   baseUrl: siteUrl,
-  defaultTitle: 'Virintira | Real Estate',
+  defaultTitle: 'Zomzom Property | Real Estate',
   description: 'Multilingual real estate partner.',
   openGraph: {
     type: 'website',
@@ -13,25 +14,25 @@ const config = {
     // List alternates excluding the default locale
     localeAlternate: ['en_US', 'zh_CN'],
     url: siteUrl,
-    site_name: 'Virintira',
+    site_name: 'Zomzom Property',
     images: [
       {
         url: `${siteUrl}og-image.png`,
         width: 1845,
         height: 871,
-        alt: 'Virintira Open Graph Image',
+        alt: 'Zomzom Property Open Graph Image',
       },
       {
         url: `${siteUrl}favicon.ico`,
         width: 256,
         height: 256,
-        alt: 'Virintira Favicon',
+        alt: 'Zomzom Property Favicon',
       },
     ],
   },
   twitter: {
-    handle: '@virintira',
-    site: '@virintira',
+    handle: '@zomzomproperty',
+    site: '@zomzomproperty',
     cardType: 'summary_large_image',
   },
   additionalMetaTags: [

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,5 +1,6 @@
 /** @type {import('next-sitemap').IConfig} */
-const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://www.virintira.com'
+const siteUrl =
+  process.env.NEXT_PUBLIC_SITE_URL || 'https://www.zomzomproperty.com'
 
 module.exports = {
   siteUrl,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "virintirarealestate",
+  "name": "zomzomproperty",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "virintirarealestate",
+      "name": "zomzomproperty",
       "version": "0.1.0",
       "dependencies": {
         "autoprefixer": "^10.4.21",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "virintirarealestate",
+  "name": "zomzomproperty",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/pages/[locale]/guides/[slug].tsx
+++ b/pages/[locale]/guides/[slug].tsx
@@ -37,7 +37,7 @@ export default function GuideDetail({ source, article }: Props) {
         title={article.title}
         images={[article.coverImage]}
         datePublished={article.publishedAt}
-        authorName={['Virintira']}
+        authorName={['Zomzom Property']}
         description={article.title}
       />
       <GuideDetailPageContent source={source} article={article} crumbs={crumbs} />

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -65,19 +65,19 @@ function MyApp({ Component, pageProps }: AppProps) {
   const orgJsonLd = {
     "@context": "https://schema.org",
     "@type": "Organization",
-    name: "Virintira",
+    name: "Zomzom Property",
     url: siteUrl,
     logo: `${baseUrl}/favicon.ico`,
     sameAs: [
-      "https://twitter.com/virintira",
-      "https://www.facebook.com/virintira",
+      "https://twitter.com/zomzomproperty",
+      "https://www.facebook.com/zomzomproperty",
     ],
   };
 
   const webSiteJsonLd = {
     "@context": "https://schema.org",
     "@type": "WebSite",
-    name: "Virintira",
+    name: "Zomzom Property",
     url: siteUrl,
   };
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -62,7 +62,7 @@ export default function Home() {
       <LocalBusinessJsonLd
         type='RealEstateAgent'
         id={siteUrl}
-        name='Virintira'
+        name='Zomzom Property'
         description='Multilingual real estate partner.'
         url={siteUrl}
         telephone='+66-2-123-4567'

--- a/scripts/section-sitemaps.js
+++ b/scripts/section-sitemaps.js
@@ -1,7 +1,8 @@
 const fs = require('fs')
 const path = require('path')
 
-const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://www.virintira.com'
+const siteUrl =
+  process.env.NEXT_PUBLIC_SITE_URL || 'https://www.zomzomproperty.com'
 const locales = ['th', 'en', 'zh']
 
 function writeSitemap(file, urls) {

--- a/src/config/contact.ts
+++ b/src/config/contact.ts
@@ -6,8 +6,8 @@ export interface ContactConfig {
 }
 
 export const CONTACT: ContactConfig = {
-  lineOA: 'https://line.me/ti/p/@virintira',
-  facebook: 'https://www.facebook.com/virintira',
-  tiktok: 'https://www.tiktok.com/@virintira',
-  phone: '+66912345678',
+  lineOA: 'https://line.me/ti/p/@zomzomproperty',
+  facebook: 'https://www.facebook.com/zomzomproperty',
+  tiktok: '',
+  phone: '+66987654321',
 }

--- a/src/lib/image/watermark.ts
+++ b/src/lib/image/watermark.ts
@@ -14,7 +14,7 @@ export async function applyWatermark(
   input: Buffer | string,
   opts: WatermarkOptions = {}
 ): Promise<Buffer> {
-  const { opacity = 0.5, margin = 10, text = 'Virintira Real Estate' } = opts
+  const { opacity = 0.5, margin = 10, text = 'Zomzom Property' } = opts
 
   const base = sharp(input)
   const metadata = await base.metadata()


### PR DESCRIPTION
## Summary
- switch site config and docs to Zomzom Property branding and URL
- update contact defaults with new links and blank unused channels
- adjust default watermark text to "Zomzom Property"

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7a42a5bb8832b846f9087a9d9f152