### PR TITLE
Use Next.js Image with shared src helper

### DIFF
--- a/pages/[locale]/properties/[id].tsx
+++ b/pages/[locale]/properties/[id].tsx
@@ -11,11 +11,7 @@ import PropertyDetailPageContent, {
   Property,
   Article,
 } from '../../../../src/views/properties/PropertyDetailPageContent'
-
-export type ImgLike = string | { src: string }
-
-export const asSrc = (img: ImgLike): string =>
-  typeof img === 'string' ? img : img.src
+import { asSrc } from '@/src/components/PropertyImage'
 
 interface Props {
   property: Property

--- a/src/components/PropertyCard.tsx
+++ b/src/components/PropertyCard.tsx
@@ -1,12 +1,7 @@
 import Link from 'next/link';
-import PropertyImage from './PropertyImage';
+import PropertyImage, { asSrc, ImgLike } from './PropertyImage';
 import { useCurrency } from '../context/CurrencyContext';
 import { formatCurrencyTHBBase } from '../lib/fx/convert';
-
-type ImgLike = string | { src: string };
-
-const asSrc = (img?: ImgLike): string | undefined =>
-  typeof img === 'string' ? img : img?.src;
 
 interface Property {
   id: number;

--- a/src/components/PropertyImage.tsx
+++ b/src/components/PropertyImage.tsx
@@ -1,26 +1,39 @@
+import Image from 'next/image'
+
 export interface ProcessedImage {
   webp: string
   avif: string
 }
 
+export type ImgLike = string | { src: string } | ProcessedImage
+
+export const FALLBACK_SRC = '/images/placeholder.jpg'
+
+export const asSrc = (img?: ImgLike): string | undefined => {
+  if (!img) return undefined
+  if (typeof img === 'string') return img
+  return 'webp' in img ? img.webp : img.src
+}
+
 interface Props {
-  src?: string
+  src?: ImgLike
   alt: string
 }
 
 export default function PropertyImage({ src, alt }: Props) {
-  const finalSrc = src || '/images/placeholder.jpg'
+  const finalSrc = asSrc(src) ?? FALLBACK_SRC
   return (
-    <img
+    <Image
       src={finalSrc}
       alt={alt}
       width={600}
       height={400}
       onError={(e) => {
         try {
-          ;(e.target as HTMLImageElement).src = '/images/placeholder.jpg'
+          e.currentTarget.src = FALLBACK_SRC
         } catch {}
       }}
     />
   )
 }
+

--- a/src/views/properties/PropertyDetailPageContent.tsx
+++ b/src/views/properties/PropertyDetailPageContent.tsx
@@ -1,12 +1,7 @@
 import Link from 'next/link'
-import PropertyImage from '../../components/PropertyImage'
+import PropertyImage, { asSrc, ImgLike } from '../../components/PropertyImage'
 import Breadcrumbs from '../../components/Breadcrumbs'
 import { Crumb } from '../../lib/nav/crumbs'
-
-type ImgLike = string | { src: string }
-
-const asSrc = (img: ImgLike): string =>
-  typeof img === 'string' ? img : img.src
 
 export interface Property {
   id: number
@@ -51,13 +46,16 @@ export default function PropertyDetailPageContent({
       <Breadcrumbs items={crumbs} />
       <div>
         {(property.images ?? []).length > 0 ? (
-          (property.images ?? []).map((img, i) => (
-            <PropertyImage
-              key={`${asSrc(img)}-${i}`}
-              src={asSrc(img)}
-              alt={`${title} image ${i + 1}`}
-            />
-          ))
+          (property.images ?? []).map((img, i) => {
+            const src = asSrc(img)
+            return (
+              <PropertyImage
+                key={src}
+                src={src}
+                alt={`${title} image ${i + 1}`}
+              />
+            )
+          })
         ) : (
           <PropertyImage src={undefined} alt={`${title} placeholder`} />
         )}


### PR DESCRIPTION
## Summary
- replace img tags with Next.js `Image` in `PropertyImage`
- expose an `asSrc` helper and fallback placeholder URL
- derive gallery keys from image sources to avoid index-based keys

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7a68fe51c832bb38595a526a44a1f