### PR TITLE
docs: document header-based locale detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,11 @@ existing file remains unchanged.
 ## Locale detection
 
 Language detection is handled by [`middleware.ts`](middleware.ts). When a path
-lacks a locale prefix, the middleware always redirects to the default locale
-(`th`). It does not inspect the `Accept-Language` header or any other request
-headers.
+lacks a locale prefix, the middleware parses the request's `Accept-Language`
+header using [`negotiator`](https://www.npmjs.com/package/negotiator) to choose
+the best match among the supported locales (`th`, `en`, `zh`). If none of the
+preferred languages match or the header is missing, the middleware redirects to
+the default locale (`th`).
 
 
 ## License


### PR DESCRIPTION
## Summary
- explain Accept-Language header parsing in middleware

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7a7e9b02c832bb5aa4580006c536f