### PR TITLE
Centralize site URL for SEO and sitemaps

### DIFF
--- a/lib/siteUrl.js
+++ b/lib/siteUrl.js
@@ -1,0 +1,3 @@
+const siteUrl = (process.env.NEXT_PUBLIC_SITE_URL || 'https://www.zomzomproperty.com').replace(/\/$/, '')
+
+module.exports = siteUrl

--- a/next-seo.config.js
+++ b/next-seo.config.js
@@ -1,8 +1,7 @@
 // next-seo.config.js
 // Default SEO configuration shared across all pages.
 // Individual pages should extend these options via the `NextSeo` component.
-const siteUrl =
-  process.env.NEXT_PUBLIC_SITE_URL || 'https://www.zomzomproperty.com/';
+import siteUrl from './lib/siteUrl.js'
 
 const config = {
   baseUrl: siteUrl,
@@ -17,13 +16,13 @@ const config = {
     site_name: 'Zomzom Property',
     images: [
       {
-        url: `${siteUrl}og-image.png`,
+        url: `${siteUrl}/og-image.png`,
         width: 1845,
         height: 871,
         alt: 'Zomzom Property Open Graph Image',
       },
       {
-        url: `${siteUrl}favicon.ico`,
+        url: `${siteUrl}/favicon.ico`,
         width: 256,
         height: 256,
         alt: 'Zomzom Property Favicon',

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,6 +1,5 @@
 /** @type {import('next-sitemap').IConfig} */
-const siteUrl =
-  process.env.NEXT_PUBLIC_SITE_URL || 'https://www.zomzomproperty.com'
+const siteUrl = require('./lib/siteUrl')
 
 module.exports = {
   siteUrl,

--- a/scripts/section-sitemaps.js
+++ b/scripts/section-sitemaps.js
@@ -1,8 +1,7 @@
 const fs = require('fs')
 const path = require('path')
 
-const siteUrl =
-  process.env.NEXT_PUBLIC_SITE_URL || 'https://www.zomzomproperty.com'
+const siteUrl = require('../lib/siteUrl')
 const locales = ['th', 'en', 'zh']
 
 function writeSitemap(file, urls) {


### PR DESCRIPTION
## Summary
- centralize site URL resolution with environment variable fallback
- update SEO config and sitemap generation to use the shared base URL

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7a96ab548832bab1429cb802a174c