### PR TITLE
feat: add cached fetch hook

### DIFF
--- a/src/components/PropertyFilters.tsx
+++ b/src/components/PropertyFilters.tsx
@@ -1,7 +1,8 @@
-import { ChangeEvent, useEffect, useState } from 'react';
+import { ChangeEvent } from 'react';
 import { PRICE_OPTIONS } from '../lib/filters/price';
 import { useCurrency } from '../context/CurrencyContext';
 import { formatCurrencyTHBBase, formatPriceTHB } from '../lib/fx/convert';
+import useCachedFetch from '../hooks/useCachedFetch';
 
 export interface Filters {
   minPrice?: number;
@@ -24,20 +25,17 @@ interface Props {
 }
 
 export default function PropertyFilters({ filters, onChange }: Props) {
-  const [amenitiesList, setAmenitiesList] = useState<string[]>([]);
-  const [transitLines, setTransitLines] = useState<Record<string, string[]>>({});
   const { currency, rates } = useCurrency();
 
-  useEffect(() => {
-    fetch('/data/amenities.json')
-      .then((res) => res.json())
-      .then((data) => setAmenitiesList(data.amenities || []))
-      .catch(() => setAmenitiesList([]));
-    fetch('/data/transit-bkk.json')
-      .then((res) => res.json())
-      .then((data) => setTransitLines(data))
-      .catch(() => setTransitLines({}));
-  }, []);
+  const { data: amenitiesData } = useCachedFetch<{ amenities: string[] }>(
+    '/data/amenities.json'
+  );
+  const { data: transitData } = useCachedFetch<Record<string, string[]>>(
+    '/data/transit-bkk.json'
+  );
+
+  const amenitiesList = amenitiesData?.amenities || [];
+  const transitLines = transitData || {};
   const handleNumberChange = (e: ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
     onChange({ ...filters, [name]: value ? Number(value) : undefined });

--- a/src/hooks/useCachedFetch.ts
+++ b/src/hooks/useCachedFetch.ts
@@ -1,0 +1,50 @@
+import { useEffect, useRef, useState } from 'react';
+
+// simple in-memory cache shared across hook instances
+const responseCache = new Map<string, unknown>();
+
+/**
+ * Fetch a JSON resource with caching and abort support.
+ *
+ * Subsequent calls with the same URL reuse cached data.
+ * Pending requests are aborted when the component unmounts.
+ */
+export default function useCachedFetch<T = unknown>(url: string) {
+  const cacheRef = useRef(responseCache);
+  const [data, setData] = useState<T | null>(() => {
+    return (cacheRef.current.get(url) as T) ?? null;
+  });
+  const [error, setError] = useState<Error | null>(null);
+  const [loading, setLoading] = useState(() => !cacheRef.current.has(url));
+
+  useEffect(() => {
+    if (cacheRef.current.has(url)) {
+      // Data already cached; no need to fetch.
+      return;
+    }
+
+    const controller = new AbortController();
+    setLoading(true);
+
+    fetch(url, { signal: controller.signal })
+      .then((res) => res.json())
+      .then((json) => {
+        cacheRef.current.set(url, json);
+        setData(json);
+        setLoading(false);
+      })
+      .catch((err) => {
+        if ((err as Error).name === 'AbortError') {
+          return;
+        }
+        setError(err as Error);
+        setLoading(false);
+      });
+
+    return () => {
+      controller.abort();
+    };
+  }, [url]);
+
+  return { data, error, loading };
+}

--- a/src/views/guides/GuidesPageContent.tsx
+++ b/src/views/guides/GuidesPageContent.tsx
@@ -5,6 +5,7 @@ import MiniSearch from 'minisearch'
 import Script from 'next/script'
 import Breadcrumbs from '../../components/Breadcrumbs'
 import { Crumb } from '../../lib/nav/crumbs'
+import useCachedFetch from '../../hooks/useCachedFetch'
 
 export interface Article {
   slug: string
@@ -28,19 +29,19 @@ export default function GuidesPageContent({ articles, categories, lang, crumbs }
   const [mini, setMini] = useState<MiniSearch<Article> | null>(null)
   const [results, setResults] = useState<Article[]>(articles)
 
+  const { data: indexData } = useCachedFetch<any>(
+    `/data/index/articles-${lang}.json`
+  )
+
   useEffect(() => {
-    async function load() {
-      const res = await fetch(`/data/index/articles-${lang}.json`)
-      const json = await res.json()
-      const m = MiniSearch.loadJSON(json, {
-        idField: 'slug',
-        fields: ['title', 'category', 'provinces'],
-        storeFields: ['slug', 'title', 'category', 'provinces'],
-      }) as MiniSearch<Article>
-      setMini(m)
-    }
-    load()
-  }, [lang])
+    if (!indexData) return
+    const m = MiniSearch.loadJSON(indexData, {
+      idField: 'slug',
+      fields: ['title', 'category', 'provinces'],
+      storeFields: ['slug', 'title', 'category', 'provinces'],
+    }) as MiniSearch<Article>
+    setMini(m)
+  }, [indexData])
 
   useEffect(() => {
     if (!mini) {


### PR DESCRIPTION
## Summary
- add `useCachedFetch` hook that caches responses and aborts in-flight requests
- use cached fetch for amenities and transit in `PropertyFilters`
- reuse cached fetch for article index in `GuidesPageContent`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7ad3cdb64832b8698dd52c1a3b775