### PR TITLE
Use async file reads in suggest API with error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,14 @@ preferred languages match or the header is missing, the middleware redirects to
 the default locale (`th`).
 
 
+## API
+
+### GET `/api/suggest`
+
+Returns search suggestions used by the client. If the suggestions file cannot
+be read, the endpoint responds with HTTP 500.
+
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/pages/api/suggest.ts
+++ b/pages/api/suggest.ts
@@ -2,8 +2,18 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import fs from 'fs';
 import path from 'path';
 
-export default function handler(req: NextApiRequest, res: NextApiResponse) {
+/**
+ * Returns search suggestions for the site.
+ *
+ * Responds with HTTP 500 if the suggestions file cannot be read.
+ */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const filePath = path.join(process.cwd(), 'public', 'data', 'index', 'suggest.json');
-  const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
-  res.status(200).json(data);
+  try {
+    const fileContents = await fs.promises.readFile(filePath, 'utf-8');
+    const data = JSON.parse(fileContents);
+    res.status(200).json(data);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to load suggestions' });
+  }
 }


### PR DESCRIPTION
## Summary
- switch suggest API to use `fs.promises.readFile`
- return HTTP 500 when suggestions file cannot be read
- document `/api/suggest` endpoint behavior

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7b0fecaf8832b9afb9eaad065c6de