### PR TITLE
Validate upload file type and size

### DIFF
--- a/pages/adminmanager.tsx
+++ b/pages/adminmanager.tsx
@@ -1,5 +1,8 @@
 import { useState, FormEvent } from 'react';
 
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/avif'];
+
 interface UploadResponse {
   webp: string;
   avif: string;
@@ -12,14 +15,40 @@ export default function AdminImageManager() {
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const form = e.currentTarget;
-    const data = new FormData(form);
+    const fileInput = form.elements.namedItem('file') as HTMLInputElement;
+    const file = fileInput?.files?.[0];
+    if (!file) {
+      setError('Please select a file');
+      setResult(null);
+      return;
+    }
+    if (!ALLOWED_TYPES.includes(file.type)) {
+      setError('Invalid file type. Please upload JPEG, PNG, WebP, or AVIF.');
+      setResult(null);
+      return;
+    }
+    if (file.size > MAX_FILE_SIZE) {
+      setError('File is too large. Maximum size is 5MB.');
+      setResult(null);
+      return;
+    }
+
+    const data = new FormData();
+    data.append('file', file);
     try {
       const res = await fetch('/api/admin/upload', {
         method: 'POST',
         body: data,
       });
       if (!res.ok) {
-        throw new Error('Upload failed');
+        let message = 'Upload failed';
+        try {
+          const errData = await res.json();
+          message = errData.error || message;
+        } catch (e) {
+          // ignore json parse errors
+        }
+        throw new Error(message);
       }
       const json = (await res.json()) as UploadResponse;
       setResult(json);


### PR DESCRIPTION
## Summary
- validate MIME type and maximum size in admin upload API
- add client-side file checks and surface server error messages

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7bdffee28832bbce851e539e655a5