### PR TITLE
feat: make watermark text configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ WATERMARK_ENABLED=true
 
 When omitted or `false`, uploads are stored without a watermark.
 
+Customize the watermark text with `WATERMARK_TEXT`:
+
+```bash
+WATERMARK_TEXT="Your brand here"
+```
+
+If not set, the default is `"Zomzom Property"`.
+
 
 ## Development
 

--- a/lib/watermarkText.ts
+++ b/lib/watermarkText.ts
@@ -1,0 +1,3 @@
+const watermarkText = process.env.WATERMARK_TEXT || 'Zomzom Property'
+
+export default watermarkText

--- a/src/lib/image/watermark.ts
+++ b/src/lib/image/watermark.ts
@@ -1,4 +1,5 @@
 import sharp from 'sharp'
+import watermarkText from '../../../lib/watermarkText'
 
 interface WatermarkOptions {
   opacity?: number
@@ -14,7 +15,7 @@ export async function applyWatermark(
   input: Buffer | string,
   opts: WatermarkOptions = {}
 ): Promise<Buffer> {
-  const { opacity = 0.5, margin = 10, text = 'Zomzom Property' } = opts
+  const { opacity = 0.5, margin = 10, text = watermarkText } = opts
 
   const base = sharp(input)
   const metadata = await base.metadata()


### PR DESCRIPTION
## Summary
- allow setting watermark text via `WATERMARK_TEXT` env var
- apply watermark using configured text instead of hardcoded default
- document `WATERMARK_TEXT`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7bf2267f0832ba5dc9c6c6b9c7e4e