### PR TITLE
Filter contact icons with empty links

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link'
 import { NAV_MAIN } from '@/src/config/nav'
 import LanguageSwitcher from './LanguageSwitcher'
 import CurrencySwitcher from '@/src/components/CurrencySwitcher'
-import { ContactIcons } from '@/src/components/ContactIcons'
+import { ContactIcons, CONTACT_ITEMS } from '@/src/components/ContactIcons'
 
 export default function Footer() {
   return (
@@ -16,7 +16,9 @@ export default function Footer() {
           ))}
           <li><LanguageSwitcher /></li>
           <li><CurrencySwitcher /></li>
-          <li><ContactIcons /></li>
+          {CONTACT_ITEMS.length > 0 && (
+            <li><ContactIcons /></li>
+          )}
         </ul>
       </nav>
     </footer>

--- a/src/components/ContactIcons.tsx
+++ b/src/components/ContactIcons.tsx
@@ -35,12 +35,17 @@ export function PhoneIcon(props: IconProps) {
   )
 }
 
-export const CONTACT_ITEMS = [
+const ALL_CONTACT_ITEMS = [
   { label: 'Line', href: CONTACT.lineOA, Icon: LineIcon },
   { label: 'Facebook', href: CONTACT.facebook, Icon: FacebookIcon },
   { label: 'TikTok', href: CONTACT.tiktok, Icon: TikTokIcon },
-  { label: 'Phone', href: `tel:${CONTACT.phone}`, Icon: PhoneIcon },
+  { label: 'Phone', href: CONTACT.phone ? `tel:${CONTACT.phone}` : undefined, Icon: PhoneIcon },
 ] as const
+
+export const CONTACT_ITEMS = ALL_CONTACT_ITEMS.filter(
+  (item): item is (typeof ALL_CONTACT_ITEMS)[number] & { href: string } =>
+    Boolean(item.href)
+)
 
 export function ContactIcons({ className = '' }: { className?: string }) {
   return (

--- a/src/components/FloatingContacts.tsx
+++ b/src/components/FloatingContacts.tsx
@@ -23,6 +23,8 @@ function XMarkIcon(props: IconProps) {
 export default function FloatingContacts() {
   const [open, setOpen] = useState(false)
 
+  if (CONTACT_ITEMS.length === 0) return null
+
   return (
     <div className="fixed bottom-4 right-4 z-50">
       <AnimatePresence>


### PR DESCRIPTION
## Summary
- skip contact channels with no hrefs
- hide contact icons in footer and floating widget when none are configured

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7c0992db8832bb71fa3ce7063dc6b