### PR TITLE
refactor: share search filter utilities

### DIFF
--- a/pages/api/search.ts
+++ b/pages/api/search.ts
@@ -4,6 +4,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import { searchParamsSchema, type SearchParams } from '../../src/lib/validation/search';
 import type { ProcessedImage } from '../../src/components/PropertyImage';
+import { applyFilters, sortResults } from '../../src/lib/search/shared';
 
 interface PropertyDTO {
   id: number;
@@ -77,44 +78,6 @@ async function loadTransit() {
     }
   }
   return transitMap;
-}
-
-function applyFilters(docs: any[], req: SearchParams) {
-  return docs.filter((doc) => {
-    if (req.minPrice !== undefined && doc.price < req.minPrice) return false;
-    if (req.maxPrice !== undefined && doc.price > req.maxPrice) return false;
-    if (req.beds !== undefined && (doc.beds ?? 0) < req.beds) return false;
-    if (req.baths !== undefined && (doc.baths ?? 0) < req.baths) return false;
-    if (req.status && doc.status !== req.status) return false;
-    if (req.freshness !== undefined) {
-      const days = (Date.now() - new Date(doc.createdAt).getTime()) / (1000 * 60 * 60 * 24);
-      if (days > req.freshness) return false;
-    }
-    if (req.nearTransit && !doc.nearTransit) return false;
-    if (req.transitLine && doc.transitLine !== req.transitLine) return false;
-    if (req.transitStation && doc.transitStation !== req.transitStation) return false;
-    if (req.furnished && doc.furnished !== req.furnished) return false;
-    if (req.amenities && req.amenities.length) {
-      for (const a of req.amenities) {
-        if (!doc.amenities.includes(a)) return false;
-      }
-    }
-    return true;
-  });
-}
-
-function sortResults(docs: any[], sort: SearchParams['sort']) {
-  switch (sort) {
-    case 'price-asc':
-      return docs.sort((a, b) => a.price - b.price);
-    case 'price-desc':
-      return docs.sort((a, b) => b.price - a.price);
-    case 'created-asc':
-      return docs.sort((a, b) => a.createdAt.localeCompare(b.createdAt));
-    case 'created-desc':
-    default:
-      return docs.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
-  }
 }
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {

--- a/src/lib/search/shared.ts
+++ b/src/lib/search/shared.ts
@@ -1,0 +1,39 @@
+import type { SearchParams } from '../validation/search';
+
+export function applyFilters(docs: any[], req: SearchParams) {
+  return docs.filter((doc) => {
+    if (req.minPrice !== undefined && doc.price < req.minPrice) return false;
+    if (req.maxPrice !== undefined && doc.price > req.maxPrice) return false;
+    if (req.beds !== undefined && (doc.beds ?? 0) < req.beds) return false;
+    if (req.baths !== undefined && (doc.baths ?? 0) < req.baths) return false;
+    if (req.status && doc.status !== req.status) return false;
+    if (req.freshness !== undefined) {
+      const days = (Date.now() - new Date(doc.createdAt).getTime()) / (1000 * 60 * 60 * 24);
+      if (days > req.freshness) return false;
+    }
+    if (req.nearTransit && !doc.nearTransit) return false;
+    if (req.transitLine && doc.transitLine !== req.transitLine) return false;
+    if (req.transitStation && doc.transitStation !== req.transitStation) return false;
+    if (req.furnished && doc.furnished !== req.furnished) return false;
+    if (req.amenities && req.amenities.length) {
+      for (const a of req.amenities) {
+        if (!doc.amenities.includes(a)) return false;
+      }
+    }
+    return true;
+  });
+}
+
+export function sortResults(docs: any[], sort: SearchParams['sort']) {
+  switch (sort) {
+    case 'price-asc':
+      return docs.sort((a, b) => a.price - b.price);
+    case 'price-desc':
+      return docs.sort((a, b) => b.price - a.price);
+    case 'created-asc':
+      return docs.sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+    case 'created-desc':
+    default:
+      return docs.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  }
+}

--- a/src/workers/search.worker.ts
+++ b/src/workers/search.worker.ts
@@ -2,6 +2,7 @@ import MiniSearch from 'minisearch';
 import { searchParamsSchema, type SearchParams } from '../lib/validation/search';
 import { MIN_PRICE, MAX_PRICE, isValidPrice } from '../lib/filters/price';
 import type { ProcessedImage } from '../components/PropertyImage';
+import { applyFilters, sortResults } from '../lib/search/shared';
 
 interface PropertyDTO {
   id: number;
@@ -67,44 +68,6 @@ async function loadTransit() {
     transitMap = await res.json();
   }
   return transitMap;
-}
-
-function applyFilters(docs: any[], req: SearchParams) {
-  return docs.filter((doc) => {
-    if (req.minPrice !== undefined && doc.price < req.minPrice) return false;
-    if (req.maxPrice !== undefined && doc.price > req.maxPrice) return false;
-    if (req.beds !== undefined && (doc.beds ?? 0) < req.beds) return false;
-    if (req.baths !== undefined && (doc.baths ?? 0) < req.baths) return false;
-    if (req.status && doc.status !== req.status) return false;
-    if (req.freshness !== undefined) {
-      const days = (Date.now() - new Date(doc.createdAt).getTime()) / (1000 * 60 * 60 * 24);
-      if (days > req.freshness) return false;
-    }
-    if (req.nearTransit && !doc.nearTransit) return false;
-    if (req.transitLine && doc.transitLine !== req.transitLine) return false;
-    if (req.transitStation && doc.transitStation !== req.transitStation) return false;
-    if (req.furnished && doc.furnished !== req.furnished) return false;
-    if (req.amenities && req.amenities.length) {
-      for (const a of req.amenities) {
-        if (!doc.amenities.includes(a)) return false;
-      }
-    }
-    return true;
-  });
-}
-
-function sortResults(docs: any[], sort: SearchParams['sort']) {
-  switch (sort) {
-    case 'price-asc':
-      return docs.sort((a, b) => a.price - b.price);
-    case 'price-desc':
-      return docs.sort((a, b) => b.price - a.price);
-    case 'created-asc':
-      return docs.sort((a, b) => a.createdAt.localeCompare(b.createdAt));
-    case 'created-desc':
-    default:
-      return docs.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
-  }
 }
 
 self.onmessage = async (event: MessageEvent<any>) => {


### PR DESCRIPTION
## Summary
- consolidate search filtering and sorting logic into `src/lib/search/shared.ts`
- reuse the shared helpers in the search worker
- reuse the shared helpers in the API search handler

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7d476992c832bb41a08d62a035a87