### PR TITLE
Add admin secret placeholders to env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,8 @@
 NEXT_PUBLIC_SITE_URL=https://www.zomzomproperty.com
 # Set to "true" to apply a text watermark when processing uploads
 WATERMARK_ENABLED=false
+
+# Admin credentials - provide values only in your local .env file. Do not commit real secrets.
+# ADMIN_USER=your_admin_username_here
+# ADMIN_HASH=your_admin_password_hash_here
+# SESSION_SECRET=your_session_secret_here


### PR DESCRIPTION
## Summary
- document admin credential environment variables in the example env file
- remind contributors not to commit real secrets when populating admin variables

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8beeb7858832bb5427f17f0acbd76