### PR TITLE
Improve PropertyImage fallbacks

### DIFF
--- a/pages/[locale]/properties/[id].tsx
+++ b/pages/[locale]/properties/[id].tsx
@@ -65,7 +65,7 @@ export default function PropertyDetail({ property, articles }: Props) {
               price: property.price,
               priceCurrency: 'THB',
             },
-            image: (property.images ?? []).map(asSrc),
+            image: (property.images ?? []).map((img) => asSrc(img)),
           }).replace(/</g, '\\u003c'),
         }}
       />

--- a/src/components/PropertyImage.tsx
+++ b/src/components/PropertyImage.tsx
@@ -7,33 +7,48 @@ export interface ProcessedImage {
 
 export type ImgLike = string | { src: string } | ProcessedImage
 
-export const FALLBACK_SRC = '/images/placeholder.jpg'
+const DEFAULT_WIDTH = 600
+const DEFAULT_HEIGHT = 400
 
-export const asSrc = (img?: ImgLike): string | undefined => {
-  if (!img) return undefined
-  if (typeof img === 'string') return img
-  return 'webp' in img ? img.webp : img.src
+const ensurePositiveInt = (value?: number): number | undefined => {
+  if (typeof value !== 'number') return undefined
+  if (!Number.isFinite(value)) return undefined
+  if (value <= 0) return undefined
+  return Math.round(value)
+}
+
+const placeholderSrc = (width?: number, height?: number): string => {
+  const finalWidth = ensurePositiveInt(width) ?? DEFAULT_WIDTH
+  const finalHeight = ensurePositiveInt(height) ?? DEFAULT_HEIGHT
+  return `https://placehold.co/${finalWidth}x${finalHeight}?text=Zomzom+Image`
+}
+
+export const asSrc = (img?: ImgLike, width?: number, height?: number): string => {
+  if (!img) return placeholderSrc(width, height)
+
+  if (typeof img === 'string') {
+    const trimmed = img.trim()
+    return trimmed ? trimmed : placeholderSrc(width, height)
+  }
+
+  const candidate = 'webp' in img ? img.webp : img.src
+  const trimmed = candidate.trim()
+  return trimmed ? trimmed : placeholderSrc(width, height)
 }
 
 interface Props {
   src?: ImgLike
   alt: string
+  w?: number
+  h?: number
+  sizes?: string
 }
 
-export default function PropertyImage({ src, alt }: Props) {
-  const finalSrc = asSrc(src) ?? FALLBACK_SRC
-  return (
-    <Image
-      src={finalSrc}
-      alt={alt}
-      width={600}
-      height={400}
-      onError={(e) => {
-        try {
-          e.currentTarget.src = FALLBACK_SRC
-        } catch {}
-      }}
-    />
-  )
+export default function PropertyImage({ src, alt, w, h, sizes }: Props) {
+  const width = ensurePositiveInt(w) ?? DEFAULT_WIDTH
+  const height = ensurePositiveInt(h) ?? DEFAULT_HEIGHT
+  const finalSrc = asSrc(src, width, height)
+
+  return <Image src={finalSrc} alt={alt} width={width} height={height} sizes={sizes} />
 }
 


### PR DESCRIPTION
## Summary
- ensure `asSrc` builds a placehold.co fallback using the requested dimensions
- add optional width, height, and sizes props to `PropertyImage` and drop the explicit error handler
- update the JSON-LD image mapping to call the new `asSrc` signature safely

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9011c753c832b894531366844c49f