### PR TITLE
Secure admin upload workflow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "next-seo": "^6.8.0",
         "next-sitemap": "^4.2.3",
         "postcss": "^8.5.6",
+        "rate-limiter-flexible": "^7.3.1",
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "react-i18next": "^15.6.0",
@@ -7100,6 +7101,12 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/rate-limiter-flexible": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/rate-limiter-flexible/-/rate-limiter-flexible-7.3.1.tgz",
+      "integrity": "sha512-nrB4jg9bu5HjG8yvLyQPyuExc4jO/rVdobSS+dl0UT7Oltll7wJpkZEZh4ByIrEnulL6QXlF21F8QoRrvtdUtg==",
+      "license": "ISC"
     },
     "node_modules/react": {
       "version": "18.3.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "next-seo": "^6.8.0",
     "next-sitemap": "^4.2.3",
     "postcss": "^8.5.6",
+    "rate-limiter-flexible": "^7.3.1",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-i18next": "^15.6.0",

--- a/pages/api/admin/upload.ts
+++ b/pages/api/admin/upload.ts
@@ -1,12 +1,31 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import formidable from 'formidable'
-import fs from 'fs'
+import fs from 'fs/promises'
 import path from 'path'
 import sharp from 'sharp'
 import { applyWatermark } from '../../../src/lib/image/watermark'
+import { getAdminSessionFromCookies } from '../../../src/lib/auth/session'
+import { parseCookies } from '../../../src/lib/http/cookies'
+import { logAuditEvent } from '../../../src/lib/logging/audit'
+import { isValidCsrfToken } from '../../../src/lib/security/csrf'
+import { consumeUploadRateLimit } from '../../../src/lib/security/rateLimit'
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024 // 5MB
 const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/avif']
+const CSRF_HEADER_NAME = 'x-csrf'
+
+function getClientIp(req: NextApiRequest): string {
+  const forwarded = req.headers['x-forwarded-for']
+  if (typeof forwarded === 'string' && forwarded.length > 0) {
+    const [first] = forwarded.split(',')
+    if (first?.trim()) return first.trim()
+  }
+  if (Array.isArray(forwarded) && forwarded.length > 0) {
+    const [first] = forwarded[0].split(',')
+    if (first?.trim()) return first.trim()
+  }
+  return req.socket?.remoteAddress ?? 'unknown'
+}
 
 export const config = {
   api: {
@@ -23,52 +42,167 @@ export default async function handler(
     return
   }
 
+  const clientIp = getClientIp(req)
+  const cookies = parseCookies(req.headers.cookie)
+  let auditActor = 'unknown'
+
+  const logFailure = async (
+    reason: string,
+    details?: Record<string, unknown>
+  ) =>
+    logAuditEvent({
+      actor: auditActor,
+      action: 'admin_upload',
+      result: 'failure',
+      ip: clientIp,
+      reason,
+      details,
+    })
+
+  const logSuccess = (details?: Record<string, unknown>) =>
+    logAuditEvent({
+      actor: auditActor,
+      action: 'admin_upload',
+      result: 'success',
+      ip: clientIp,
+      details,
+    })
+
+  const rateLimitRes = await consumeUploadRateLimit(clientIp)
+  if (rateLimitRes) {
+    res.setHeader('Retry-After', Math.ceil(rateLimitRes.msBeforeNext / 1000))
+    await logFailure('rate_limited', { msBeforeNext: rateLimitRes.msBeforeNext })
+    res.status(429).json({ error: 'Too many requests' })
+    return
+  }
+
+  if (!isValidCsrfToken(cookies, req.headers[CSRF_HEADER_NAME])) {
+    await logFailure('csrf_mismatch')
+    res.status(403).json({ error: 'Invalid CSRF token' })
+    return
+  }
+
+  const session = getAdminSessionFromCookies(cookies)
+  if (!session) {
+    await logFailure('unauthorized')
+    res.status(401).json({ error: 'Unauthorized' })
+    return
+  }
+
+  auditActor = session.username
+
   const form = formidable({ multiples: false, maxFileSize: MAX_FILE_SIZE })
 
-  form.parse(req, async (err, fields, files) => {
-    if (err) {
-      if ((err as any).httpCode === 413) {
-        res.status(400).json({ error: 'File is too large' })
-      } else {
-        res.status(500).json({ error: 'Failed to parse form' })
-      }
-      return
-    }
-
-    const file = files.file as formidable.File | formidable.File[] | undefined
-    if (!file || Array.isArray(file)) {
-      res.status(400).json({ error: 'No file uploaded' })
-      return
-    }
-
-    if (!ALLOWED_TYPES.includes(file.mimetype || '')) {
-      res.status(400).json({ error: 'Invalid file type' })
-      return
-    }
-
-    if (file.size > MAX_FILE_SIZE) {
+  let files: formidable.Files
+  try {
+    const parsed = (await form.parse(req)) as [
+      formidable.Fields,
+      formidable.Files
+    ]
+    files = parsed[1]
+  } catch (error: unknown) {
+    const httpCode =
+      typeof error === 'object' && error && 'httpCode' in error
+        ? (error as { httpCode?: number }).httpCode
+        : undefined
+    if (httpCode === 413) {
+      await logFailure('file_too_large', { stage: 'parse' })
       res.status(400).json({ error: 'File is too large' })
-      return
+    } else {
+      await logFailure('form_parse_failed', {
+        error: error instanceof Error ? error.message : 'unknown',
+      })
+      res.status(500).json({ error: 'Failed to parse form' })
     }
+    return
+  }
 
-    let buffer = await fs.promises.readFile(file.filepath)
+  const uploaded = files.file as
+    | formidable.File
+    | formidable.File[]
+    | undefined
+  if (!uploaded || Array.isArray(uploaded)) {
+    await logFailure('missing_file')
+    res.status(400).json({ error: 'No file uploaded' })
+    return
+  }
+
+  const file = uploaded
+
+  if (!ALLOWED_TYPES.includes(file.mimetype || '')) {
+    await logFailure('invalid_file_type', {
+      mimetype: file.mimetype ?? null,
+    })
+    res.status(400).json({ error: 'Invalid file type' })
+    return
+  }
+
+  if (file.size > MAX_FILE_SIZE) {
+    await logFailure('file_too_large', { size: file.size })
+    res.status(400).json({ error: 'File is too large' })
+    return
+  }
+
+  let buffer: Buffer
+  try {
+    buffer = await fs.readFile(file.filepath)
+  } catch (error: unknown) {
+    await logFailure('file_read_failed', {
+      error: error instanceof Error ? error.message : 'unknown',
+    })
+    res.status(500).json({ error: 'Failed to read uploaded file' })
+    return
+  }
+
+  try {
     if (process.env.WATERMARK_ENABLED === 'true') {
       buffer = await applyWatermark(buffer)
     }
+  } catch (error: unknown) {
+    await logFailure('watermark_failed', {
+      error: error instanceof Error ? error.message : 'unknown',
+    })
+    res.status(500).json({ error: 'Failed to apply watermark' })
+    return
+  }
 
-    const processedDir = path.join(process.cwd(), 'public', 'uploads', 'processed')
-    await fs.promises.mkdir(processedDir, { recursive: true })
+  const processedDir = path.join(process.cwd(), 'public', 'uploads', 'processed')
+  try {
+    await fs.mkdir(processedDir, { recursive: true })
+  } catch (error: unknown) {
+    await logFailure('directory_prepare_failed', {
+      error: error instanceof Error ? error.message : 'unknown',
+    })
+    res.status(500).json({ error: 'Failed to prepare upload directory' })
+    return
+  }
 
-    const baseName = path.parse(file.originalFilename || 'upload').name
-    const webpPath = path.join(processedDir, `${baseName}.webp`)
-    const avifPath = path.join(processedDir, `${baseName}.avif`)
+  const baseName = path.parse(file.originalFilename || 'upload').name
+  const webpPath = path.join(processedDir, `${baseName}.webp`)
+  const avifPath = path.join(processedDir, `${baseName}.avif`)
 
+  try {
     await sharp(buffer).webp().toFile(webpPath)
     await sharp(buffer).avif().toFile(avifPath)
-
-    res.status(200).json({
-      webp: `/uploads/processed/${baseName}.webp`,
-      avif: `/uploads/processed/${baseName}.avif`,
+  } catch (error: unknown) {
+    await logFailure('image_processing_failed', {
+      error: error instanceof Error ? error.message : 'unknown',
     })
+    res.status(500).json({ error: 'Failed to process image' })
+    return
+  }
+
+  const responsePayload = {
+    webp: `/uploads/processed/${baseName}.webp`,
+    avif: `/uploads/processed/${baseName}.avif`,
+  }
+
+  await logSuccess({
+    filename: file.originalFilename ?? null,
+    mimetype: file.mimetype ?? null,
+    size: file.size,
+    outputs: responsePayload,
   })
+
+  res.status(200).json(responsePayload)
 }

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -1,0 +1,86 @@
+import crypto from 'crypto';
+import type { CookieMap } from '../http/cookies';
+
+export interface AdminSession {
+  username: string;
+  issuedAt?: number;
+  expiresAt: number;
+}
+
+const SESSION_COOKIE_NAME = 'admin_session';
+
+function constantTimeCompare(expected: string, provided: string): boolean {
+  try {
+    const expectedBuffer = Buffer.from(expected, 'hex');
+    const providedBuffer = Buffer.from(provided, 'hex');
+    if (expectedBuffer.length !== providedBuffer.length) {
+      return false;
+    }
+    return crypto.timingSafeEqual(expectedBuffer, providedBuffer);
+  } catch {
+    return false;
+  }
+}
+
+export function getAdminSessionFromCookies(cookies: CookieMap): AdminSession | null {
+  const sessionCookie = cookies[SESSION_COOKIE_NAME];
+  const secret = process.env.SESSION_SECRET;
+  const expectedUser = process.env.ADMIN_USER;
+
+  if (!sessionCookie || !secret || !expectedUser) {
+    return null;
+  }
+
+  const [payloadPart, signaturePart] = sessionCookie.split('.');
+  if (!payloadPart || !signaturePart) {
+    return null;
+  }
+
+  const hmac = crypto.createHmac('sha256', secret);
+  hmac.update(payloadPart);
+  const expectedSignature = hmac.digest('hex');
+
+  if (!constantTimeCompare(expectedSignature, signaturePart)) {
+    return null;
+  }
+
+  let payloadJson: string;
+  try {
+    payloadJson = Buffer.from(payloadPart, 'base64url').toString('utf8');
+  } catch {
+    return null;
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(payloadJson);
+  } catch {
+    return null;
+  }
+
+  if (!payload || typeof payload !== 'object') {
+    return null;
+  }
+
+  const { username, expiresAt, issuedAt } = payload as {
+    username?: unknown;
+    expiresAt?: unknown;
+    issuedAt?: unknown;
+  };
+
+  if (typeof username !== 'string' || username !== expectedUser) {
+    return null;
+  }
+
+  if (typeof expiresAt !== 'number' || Number.isNaN(expiresAt) || expiresAt <= Date.now()) {
+    return null;
+  }
+
+  const parsedIssuedAt = typeof issuedAt === 'number' ? issuedAt : undefined;
+
+  return {
+    username,
+    expiresAt,
+    issuedAt: parsedIssuedAt,
+  };
+}

--- a/src/lib/http/cookies.ts
+++ b/src/lib/http/cookies.ts
@@ -1,0 +1,28 @@
+export type CookieMap = Record<string, string>;
+
+function safeDecode(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+export function parseCookies(cookieHeader?: string | null): CookieMap {
+  if (!cookieHeader) return {};
+
+  const cookies: CookieMap = {};
+  const pairs = cookieHeader.split(';');
+
+  for (const pair of pairs) {
+    if (!pair) continue;
+    const [rawName, ...rest] = pair.trim().split('=');
+    if (!rawName) continue;
+
+    const name = safeDecode(rawName);
+    const value = rest.length > 0 ? rest.join('=') : '';
+    cookies[name] = safeDecode(value);
+  }
+
+  return cookies;
+}

--- a/src/lib/logging/audit.ts
+++ b/src/lib/logging/audit.ts
@@ -1,0 +1,28 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+export interface AuditEvent {
+  timestamp?: string;
+  actor: string;
+  action: string;
+  result: 'success' | 'failure';
+  ip?: string;
+  reason?: string;
+  details?: Record<string, unknown>;
+}
+
+const auditLogPath = path.join(process.cwd(), 'logs', 'audit.log');
+
+export async function logAuditEvent(event: AuditEvent): Promise<void> {
+  const entry = {
+    ...event,
+    timestamp: event.timestamp ?? new Date().toISOString(),
+  };
+
+  try {
+    await fs.mkdir(path.dirname(auditLogPath), { recursive: true });
+    await fs.appendFile(auditLogPath, `${JSON.stringify(entry)}\n`, { encoding: 'utf8' });
+  } catch (error) {
+    console.error('Failed to write audit log entry', error);
+  }
+}

--- a/src/lib/security/csrf.ts
+++ b/src/lib/security/csrf.ts
@@ -1,0 +1,32 @@
+import crypto from 'crypto';
+import type { CookieMap } from '../http/cookies';
+
+export interface CsrfValidationOptions {
+  cookieName?: string;
+}
+
+export function isValidCsrfToken(
+  cookies: CookieMap,
+  headerValue: string | string[] | undefined,
+  options: CsrfValidationOptions = {}
+): boolean {
+  const cookieName = options.cookieName ?? 'csrf_token';
+  const tokenFromCookie = cookies[cookieName];
+  const headerToken = Array.isArray(headerValue) ? headerValue[0] : headerValue;
+
+  if (!tokenFromCookie || typeof headerToken !== 'string' || headerToken.length === 0) {
+    return false;
+  }
+
+  if (tokenFromCookie.length !== headerToken.length) {
+    return false;
+  }
+
+  try {
+    const cookieBuffer = Buffer.from(tokenFromCookie, 'utf8');
+    const headerBuffer = Buffer.from(headerToken, 'utf8');
+    return crypto.timingSafeEqual(cookieBuffer, headerBuffer);
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/security/rateLimit.ts
+++ b/src/lib/security/rateLimit.ts
@@ -1,0 +1,21 @@
+import { RateLimiterMemory, RateLimiterRes } from 'rate-limiter-flexible';
+
+const points = Number.parseInt(process.env.UPLOAD_RATE_LIMIT_POINTS ?? '5', 10);
+const duration = Number.parseInt(process.env.UPLOAD_RATE_LIMIT_DURATION ?? '60', 10);
+
+const uploadRateLimiter = new RateLimiterMemory({
+  points: Number.isFinite(points) && points > 0 ? points : 5,
+  duration: Number.isFinite(duration) && duration > 0 ? duration : 60,
+});
+
+export async function consumeUploadRateLimit(key: string): Promise<RateLimiterRes | null> {
+  try {
+    await uploadRateLimiter.consume(key);
+    return null;
+  } catch (error) {
+    if (error instanceof RateLimiterRes) {
+      return error;
+    }
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary
- enforce admin session verification, CSRF validation, and audit logging on the admin upload API
- add IP-based rate limiting to upload requests using rate-limiter-flexible
- introduce reusable helpers for cookies, sessions, CSRF checks, rate limiting, and audit logging

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9047bec14832bbae1e00940ca92a5