### PR TITLE
Adjust search worker filtering and fuzzy matching

### DIFF
--- a/src/lib/search/shared.ts
+++ b/src/lib/search/shared.ts
@@ -2,6 +2,8 @@ import type { SearchParams } from '../validation/search';
 
 export function applyFilters(docs: any[], req: SearchParams) {
   return docs.filter((doc) => {
+    if (req.province && doc.province !== req.province && doc.province_th !== req.province) return false;
+    if (req.type && doc.type !== req.type) return false;
     if (req.minPrice !== undefined && doc.price < req.minPrice) return false;
     if (req.maxPrice !== undefined && doc.price > req.maxPrice) return false;
     if (req.beds !== undefined && (doc.beds ?? 0) < req.beds) return false;


### PR DESCRIPTION
## Summary
- add fuzzy search tuning for worker-side MiniSearch queries
- defer numeric and enum filtering until after text matches are gathered
- extend shared filter utility to enforce province and type constraints post search

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c90841d1c8832ba2e435d2c56e5882