### PR TITLE
Update build process to include sitemap generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "next build && next-sitemap",
     "start": "node server.js",
     "test": "node --test",
     "lint": "next lint",
-    "postbuild": "next-sitemap && node scripts/section-sitemaps.js",
+    "postbuild": "node scripts/section-sitemaps.js",
     "update:rates": "ts-node --compiler-options '{\"module\":\"CommonJS\"}' scripts/update-rates.ts",
     "i18n:check": "ts-node scripts/i18n-check.ts || echo 'i18n check: warned'",
     "index:build": "ts-node --compiler-options '{\"module\":\"CommonJS\"}' src/lib/search/indexBuilder.ts"


### PR DESCRIPTION
## Summary
- update the build script to run `next-sitemap` immediately after `next build`
- adjust the postbuild script so only the section sitemap generation remains separate

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c9611f2d44832bad73467bcac776e2