### PR TITLE
Add security headers and cache control for index data

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,47 @@
 const { i18n } = require('./next-i18next.config')
+
+const securityHeaders = [
+  {
+    key: 'Strict-Transport-Security',
+    value: 'max-age=63072000; includeSubDomains; preload',
+  },
+  {
+    key: 'X-Content-Type-Options',
+    value: 'nosniff',
+  },
+  {
+    key: 'X-Frame-Options',
+    value: 'SAMEORIGIN',
+  },
+  {
+    key: 'Referrer-Policy',
+    value: 'strict-origin-when-cross-origin',
+  },
+  {
+    key: 'Permissions-Policy',
+    value: 'camera=(), microphone=(), geolocation=()',
+  },
+]
+
+const indexCacheHeaders = [
+  {
+    key: 'Cache-Control',
+    value: 'public, max-age=31536000, immutable',
+  },
+]
+
 module.exports = {
   i18n,
-  // ...อื่นๆ
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: securityHeaders,
+      },
+      {
+        source: '/data/index/:path*',
+        headers: indexCacheHeaders,
+      },
+    ]
+  },
 }


### PR DESCRIPTION
## Summary
- add a headers() config to apply standard security headers to all routes
- configure cache-control for index shard JSON assets

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c961b367e0832bb9de9b1cfbf8cd49