### PR TITLE
Refine navigation data for mega and mobile menus

### DIFF
--- a/components/Header/NavBar.tsx
+++ b/components/Header/NavBar.tsx
@@ -30,15 +30,18 @@ export default function NavBar() {
         </button>
         <div className="flex items-center gap-4">
           <ul className="hidden md:flex gap-4 items-center">
-            {NAV_MAIN.map((item) => (
-              <li key={item.title}>
-                {item.children ? (
-                  <MegaMenu item={item} />
-                ) : (
-                  <Link href={item.href ?? '#'}>{item.title}</Link>
-                )}
-              </li>
-            ))}
+            {NAV_MAIN.map((item) => {
+              const hasSections = item.sections && item.sections.length > 0
+              return (
+                <li key={item.title}>
+                  {hasSections ? (
+                    <MegaMenu item={item} />
+                  ) : (
+                    <Link href={item.href ?? '#'}>{item.title}</Link>
+                  )}
+                </li>
+              )
+            })}
             <li><LanguageSwitcher /></li>
             <li><CurrencySwitcher /></li>
           </ul>

--- a/components/MegaMenu.tsx
+++ b/components/MegaMenu.tsx
@@ -9,7 +9,7 @@ interface MegaMenuProps {
 export default function MegaMenu({ item }: MegaMenuProps) {
   const [open, setOpen] = useState(false)
   const buttonRef = useRef<HTMLButtonElement>(null)
-  const menuRef = useRef<HTMLUListElement>(null)
+  const menuRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
@@ -23,6 +23,19 @@ export default function MegaMenu({ item }: MegaMenuProps) {
   }, [open])
 
   useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      const target = e.target as Node
+      if (!menuRef.current?.contains(target) && !buttonRef.current?.contains(target)) {
+        setOpen(false)
+      }
+    }
+    if (open) {
+      document.addEventListener('mousedown', handleClick)
+    }
+    return () => document.removeEventListener('mousedown', handleClick)
+  }, [open])
+
+  useEffect(() => {
     if (open) menuRef.current?.querySelector('a')?.focus()
   }, [open])
 
@@ -30,30 +43,69 @@ export default function MegaMenu({ item }: MegaMenuProps) {
     typeof window !== 'undefined' &&
     window.matchMedia('(prefers-reduced-motion: reduce)').matches
 
+  const hasSections = item.sections && item.sections.length > 0
+
   return (
     <div className="relative">
       <button
         ref={buttonRef}
         aria-haspopup="true"
         aria-expanded={open}
-        onClick={() => setOpen(!open)}
+        onClick={() => hasSections && setOpen((value) => !value)}
+        disabled={!hasSections}
       >
         {item.title}
       </button>
-      {open && (
-        <ul
+      {open && hasSections && (
+        <div
           ref={menuRef}
           role="menu"
-          className={`absolute mt-2 bg-white shadow ${prefersReduced ? '' : 'transition-opacity duration-200'}`}
+          className={`absolute left-1/2 z-20 mt-2 w-screen max-w-4xl -translate-x-1/2 rounded-md border border-gray-200 bg-white shadow-lg focus:outline-none ${
+            prefersReduced ? '' : 'transition-opacity duration-200'
+          }`}
         >
-          {item.children?.map((child) => (
-            <li key={child.title} role="none">
-              <Link role="menuitem" href={child.href ?? '#'} className="block px-4 py-2">
-                {child.title}
-              </Link>
-            </li>
-          ))}
-        </ul>
+          <div className="grid gap-6 p-6 sm:grid-cols-2 lg:grid-cols-3">
+            {item.href && (
+              <div className="sm:col-span-2 lg:col-span-3">
+                <Link
+                  href={item.href}
+                  className="inline-flex items-center gap-2 text-sm font-semibold text-blue-600 hover:text-blue-500"
+                  onClick={() => setOpen(false)}
+                >
+                  View all {item.title}
+                </Link>
+                {item.description && (
+                  <p className="mt-1 text-sm text-gray-600">{item.description}</p>
+                )}
+              </div>
+            )}
+            {item.sections?.map((section) => (
+              <div key={section.title} className="space-y-2">
+                <p className="text-sm font-semibold text-gray-900">{section.title}</p>
+                {section.description && (
+                  <p className="text-xs text-gray-600">{section.description}</p>
+                )}
+                <ul className="space-y-2">
+                  {section.items.map((link) => (
+                    <li key={link.title} role="none">
+                      <Link
+                        role="menuitem"
+                        href={link.href}
+                        className="block rounded-md px-3 py-2 text-sm text-gray-700 transition hover:bg-gray-50 hover:text-gray-900"
+                        onClick={() => setOpen(false)}
+                      >
+                        <span className="font-medium">{link.title}</span>
+                        {link.description && (
+                          <span className="mt-1 block text-xs text-gray-500">{link.description}</span>
+                        )}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        </div>
       )}
     </div>
   )

--- a/components/MobileMenu.tsx
+++ b/components/MobileMenu.tsx
@@ -40,31 +40,68 @@ export default function MobileMenu({ open, onClose, items, children }: MobileMen
       ref={menuRef}
       role="dialog"
       aria-modal="true"
-      className={`md:hidden fixed inset-0 bg-white p-4 overflow-auto ${prefersReduced ? '' : 'transition-transform duration-200'}`}
+      className={`md:hidden fixed inset-0 bg-white p-4 overflow-auto ${
+        prefersReduced ? '' : 'transition-transform duration-200'
+      }`}
     >
-      <button onClick={onClose} className="mb-4">
+      <button onClick={onClose} className="mb-4 text-sm font-semibold text-gray-600">
         Close
       </button>
-      <ul className="flex flex-col gap-4" role="menu">
-        {items.map((item) => (
-          <li key={item.title} role="none">
-            <Link href={item.href ?? '#'} role="menuitem" className="block">
-              {item.title}
-            </Link>
-            {item.children && (
-              <ul className="ml-4 mt-2 flex flex-col gap-2" role="menu">
-                {item.children.map((child) => (
-                  <li key={child.title} role="none">
-                    <Link href={child.href ?? '#'} role="menuitem" className="block">
-                      {child.title}
-                    </Link>
-                  </li>
-                ))}
-              </ul>
-            )}
-          </li>
-        ))}
-        {children && <li role="none" className="mt-4 flex gap-4 items-center">{children}</li>}
+      <ul className="flex flex-col gap-6" role="menu">
+        {items.map((item) => {
+          const hasSections = item.sections && item.sections.length > 0
+          return (
+            <li key={item.title} role="none" className="space-y-3">
+              {item.href ? (
+                <Link
+                  href={item.href}
+                  role="menuitem"
+                  className="text-lg font-semibold"
+                  onClick={onClose}
+                >
+                  {item.title}
+                </Link>
+              ) : (
+                <span className="text-lg font-semibold" role="presentation">
+                  {item.title}
+                </span>
+              )}
+              {item.description && (
+                <p className="text-sm text-gray-600">{item.description}</p>
+              )}
+              {hasSections && (
+                <div className="space-y-4" role="group" aria-label={`${item.title} sections`}>
+                  {item.sections!.map((section) => (
+                    <div key={section.title} className="rounded-lg border border-gray-100 bg-gray-50 p-3">
+                      <p className="text-sm font-semibold text-gray-900">{section.title}</p>
+                      {section.description && (
+                        <p className="mt-1 text-xs text-gray-600">{section.description}</p>
+                      )}
+                      <ul className="mt-2 space-y-2" role="menu">
+                        {section.items.map((link) => (
+                          <li key={link.title} role="none">
+                            <Link
+                              href={link.href}
+                              role="menuitem"
+                              className="block rounded-md px-3 py-2 text-sm text-gray-700 hover:bg-white hover:text-gray-900"
+                              onClick={onClose}
+                            >
+                              <span className="font-medium">{link.title}</span>
+                              {link.description && (
+                                <span className="mt-1 block text-xs text-gray-500">{link.description}</span>
+                              )}
+                            </Link>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </li>
+          )
+        })}
+        {children && <li role="none" className="mt-2 flex flex-wrap gap-4 items-center">{children}</li>}
       </ul>
     </div>
   )

--- a/src/config/nav.ts
+++ b/src/config/nav.ts
@@ -1,17 +1,241 @@
+export interface NavLink {
+  title: string
+  href: string
+  description?: string
+}
+
+export interface NavSection {
+  title: string
+  description?: string
+  items: NavLink[]
+}
+
 export interface NavItem {
   title: string
   href?: string
-  children?: NavItem[]
+  description?: string
+  sections?: NavSection[]
 }
 
 export const NAV_MAIN: NavItem[] = [
-  { title: 'Home', href: '/' },
   {
-    title: 'Properties',
-    children: [
-      { title: 'Buy', href: '/buy' },
-      { title: 'Rent', href: '/rent' },
+    title: 'Buy',
+    href: '/properties?status=sale',
+    description: 'Explore properties for sale across Thailand.',
+    sections: [
+      {
+        title: 'Popular areas',
+        description: 'In-demand destinations for buyers.',
+        items: [
+          {
+            title: 'Bangkok homes for sale',
+            href: '/properties?status=sale&province=Bangkok',
+            description: 'Luxury condos and city homes in the capital.',
+          },
+          {
+            title: 'Phuket villas for sale',
+            href: '/properties?status=sale&province=Phuket',
+            description: 'Beachfront escapes and hillside retreats.',
+          },
+          {
+            title: 'Pattaya homes for sale',
+            href: '/properties?status=sale&province=Chon Buri',
+            description: 'Resort properties along the eastern seaboard.',
+          },
+        ],
+      },
+      {
+        title: 'Property types',
+        description: 'Narrow listings to the format that suits you best.',
+        items: [
+          { title: 'Condos for sale', href: '/properties?status=sale&type=condo' },
+          { title: 'Houses for sale', href: '/properties?status=sale&type=house' },
+          { title: 'Townhouses for sale', href: '/properties?status=sale&type=townhouse' },
+          { title: 'Land for sale', href: '/properties?status=sale&type=land' },
+        ],
+      },
+      {
+        title: 'Buyer resources',
+        description: 'Understand the process and finance options.',
+        items: [
+          { title: 'National buying process', href: '/guides/national-buying-process' },
+          { title: 'Thailand mortgage basics', href: '/guides/thailand-mortgage-basics' },
+          { title: 'Bangkok tax advice', href: '/guides/bangkok-tax-advice' },
+        ],
+      },
     ],
   },
-  { title: 'Contact', href: '/contact' },
+  {
+    title: 'Rent',
+    href: '/properties?status=rent',
+    description: 'Find condos and houses available for lease.',
+    sections: [
+      {
+        title: 'Top cities',
+        description: 'Rental markets with the most active supply.',
+        items: [
+          { title: 'Bangkok rentals', href: '/properties?status=rent&province=Bangkok' },
+          { title: 'Phuket rentals', href: '/properties?status=rent&province=Phuket' },
+          { title: 'Pattaya rentals', href: '/properties?status=rent&province=Chon Buri' },
+        ],
+      },
+      {
+        title: 'By property type',
+        description: 'Browse rentals by layout and amenities.',
+        items: [
+          { title: 'Condos for rent', href: '/properties?status=rent&type=condo' },
+          { title: 'Houses for rent', href: '/properties?status=rent&type=house' },
+          { title: 'Townhouses for rent', href: '/properties?status=rent&type=townhouse' },
+        ],
+      },
+      {
+        title: 'Rental advice',
+        description: 'Stay informed before signing your next lease.',
+        items: [
+          { title: 'Pattaya townhouse rental guide', href: '/guides/pattaya-townhouse-rental' },
+          { title: 'Bangkok condo renovation tips', href: '/guides/bangkok-condo-renovation' },
+          { title: 'Chiang Mai market trends', href: '/guides/chiangmai-market-trends' },
+        ],
+      },
+    ],
+  },
+  {
+    title: 'Condos',
+    href: '/properties?type=condo',
+    description: 'Condominium listings and expert insights.',
+    sections: [
+      {
+        title: 'Condos by area',
+        description: 'Urban hotspots and coastal developments.',
+        items: [
+          { title: 'Bangkok condos', href: '/properties?type=condo&province=Bangkok' },
+          { title: 'Phuket condos', href: '/properties?type=condo&province=Phuket' },
+          { title: 'Pattaya condos', href: '/properties?type=condo&province=Chon Buri' },
+        ],
+      },
+      {
+        title: 'Plan your move',
+        description: 'Guides to buying and maintaining condos.',
+        items: [
+          { title: 'Bangkok condo buying guide', href: '/guides/bangkok-condo-guide' },
+          { title: 'Chiang Mai condo rules', href: '/guides/chiangmai-condo-rules' },
+          { title: 'Bangkok condo renovation', href: '/guides/bangkok-condo-renovation' },
+        ],
+      },
+      {
+        title: 'Finance and legal',
+        description: 'Navigate fees, financing, and ownership.',
+        items: [
+          { title: 'National buying process', href: '/guides/national-buying-process' },
+          { title: 'Thailand mortgage basics', href: '/guides/thailand-mortgage-basics' },
+          { title: 'Bangkok tax advice', href: '/guides/bangkok-tax-advice' },
+        ],
+      },
+    ],
+  },
+  {
+    title: 'Houses',
+    href: '/properties?type=house',
+    description: 'Detached homes, villas, and family estates.',
+    sections: [
+      {
+        title: 'Houses by area',
+        description: 'City and resort destinations with villas and homes.',
+        items: [
+          { title: 'Bangkok houses', href: '/properties?type=house&province=Bangkok' },
+          { title: 'Phuket villas', href: '/properties?type=house&province=Phuket' },
+          { title: 'Pattaya houses', href: '/properties?type=house&province=Chon Buri' },
+        ],
+      },
+      {
+        title: 'Inspiration',
+        description: 'Homeownership tips from around Thailand.',
+        items: [
+          { title: 'Chiang Mai house tips', href: '/guides/chiangmai-house-tips' },
+          { title: 'Phuket villa maintenance', href: '/guides/phuket-villa-maintenance' },
+          { title: 'Phuket land investment', href: '/guides/phuket-land-investment' },
+        ],
+      },
+      {
+        title: 'Townhomes and land',
+        description: 'Look beyond single-family homes.',
+        items: [
+          { title: 'Townhouses for sale', href: '/properties?type=townhouse' },
+          { title: 'Land investment opportunities', href: '/properties?type=land' },
+          { title: 'Phuket beachfront plots', href: '/guides/phuket-beachfront-plots' },
+        ],
+      },
+    ],
+  },
+  {
+    title: 'Areas',
+    href: '/properties?province=Bangkok',
+    description: 'Browse properties and guides by destination.',
+    sections: [
+      {
+        title: 'Bangkok',
+        description: 'Thailand’s vibrant capital and business hub.',
+        items: [
+          { title: 'Buy in Bangkok', href: '/properties?province=Bangkok&status=sale' },
+          { title: 'Rent in Bangkok', href: '/properties?province=Bangkok&status=rent' },
+          { title: 'Bangkok condos', href: '/properties?province=Bangkok&type=condo' },
+          { title: 'Bangkok guides', href: '/guides/bangkok-condo-guide' },
+        ],
+      },
+      {
+        title: 'Phuket',
+        description: 'Island living with world-class beaches.',
+        items: [
+          { title: 'Buy in Phuket', href: '/properties?province=Phuket&status=sale' },
+          { title: 'Rent in Phuket', href: '/properties?province=Phuket&status=rent' },
+          { title: 'Phuket villas', href: '/properties?province=Phuket&type=house' },
+          { title: 'Phuket guides', href: '/guides/phuket-villa-maintenance' },
+        ],
+      },
+      {
+        title: 'Pattaya',
+        description: 'Resort living on the eastern seaboard.',
+        items: [
+          { title: 'Buy in Pattaya', href: '/properties?province=Chon Buri&status=sale' },
+          { title: 'Rent in Pattaya', href: '/properties?province=Chon Buri&status=rent' },
+          { title: 'Pattaya condos', href: '/properties?province=Chon Buri&type=condo' },
+          { title: 'Pattaya guides', href: '/guides/pattaya-townhouse-rental' },
+        ],
+      },
+    ],
+  },
+  {
+    title: 'Guides',
+    href: '/guides',
+    description: 'Research the Thai property market before you buy or rent.',
+    sections: [
+      {
+        title: 'Buying essentials',
+        description: 'Key steps and requirements for overseas buyers.',
+        items: [
+          { title: 'National buying process', href: '/guides/national-buying-process' },
+          { title: 'Thailand mortgage basics', href: '/guides/thailand-mortgage-basics' },
+          { title: 'Bangkok tax advice', href: '/guides/bangkok-tax-advice' },
+        ],
+      },
+      {
+        title: 'Area spotlights',
+        description: 'Deep dives into Thailand’s favourite destinations.',
+        items: [
+          { title: 'Bangkok condo buying guide', href: '/guides/bangkok-condo-guide' },
+          { title: 'Phuket villa maintenance', href: '/guides/phuket-villa-maintenance' },
+          { title: 'Pattaya townhouse rental', href: '/guides/pattaya-townhouse-rental' },
+        ],
+      },
+      {
+        title: 'Investment insights',
+        description: 'Stay ahead of market and development trends.',
+        items: [
+          { title: 'Chiang Mai market trends', href: '/guides/chiangmai-market-trends' },
+          { title: 'Phuket land investment', href: '/guides/phuket-land-investment' },
+          { title: 'Bangkok condo renovation', href: '/guides/bangkok-condo-renovation' },
+        ],
+      },
+    ],
+  },
 ]


### PR DESCRIPTION
## Summary
- replace the main navigation config with structured sections for buy, rent, condos, houses, areas, and guides
- update the desktop mega menu to render grouped section links and close on outside interactions
- refresh the mobile slide-out menu and navbar to consume the sectioned navigation data

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c974196b84832bb900b838b3fc47b5