### PR TITLE
Add admin login API with database-backed auth

### DIFF
--- a/.env
+++ b/.env
@@ -13,3 +13,12 @@ SESSION_SECRET=UjKwwNef1fjRw_2WzUbJeXDJlA3LdVR0iGjulImEIKJgHFcf32gFMBVXG5HRDyPSo
 
 # (ตัวเลือก) ปิดเทเลเมทรีของ Next.js
 NEXT_TELEMETRY_DISABLED=1
+
+# (ตัวเลือก) ใช้ฐานข้อมูลสำหรับล็อกอินแอดมิน
+# ADMIN_DB_AUTH_ENABLED=false
+# ADMIN_DB_URL=postgres://user:pass@localhost:5432/app
+# ADMIN_DB_TABLE=admin_users
+# ADMIN_DB_USERNAME_COLUMN=username
+# ADMIN_DB_PASSWORD_HASH_COLUMN=password_hash
+# ADMIN_DB_ACTIVE_COLUMN=is_active
+# ADMIN_DB_SSL=false

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "next-mdx-remote": "^4.4.1",
         "next-seo": "^6.8.0",
         "next-sitemap": "^4.2.3",
+        "pg": "^8.16.3",
         "postcss": "^8.5.6",
         "rate-limiter-flexible": "^7.3.1",
         "react": "18.3.1",
@@ -32,6 +33,7 @@
       },
       "devDependencies": {
         "@testing-library/react": "^16.3.0",
+        "@types/bcryptjs": "^2.4.6",
         "@types/formidable": "^3.4.5",
         "@types/negotiator": "^0.6.4",
         "@types/node": "^20.19.8",
@@ -1317,6 +1319,13 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/@types/bcryptjs": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
+      "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/debug": {
       "version": "4.1.12",
@@ -6851,6 +6860,95 @@
         "is-reference": "^3.0.0"
       }
     },
+    "node_modules/pg": {
+      "version": "8.16.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
+      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.9.1",
+        "pg-pool": "^3.10.1",
+        "pg-protocol": "^1.10.3",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.2.7"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.2.7.tgz",
+      "integrity": "sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.1.tgz",
+      "integrity": "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.1.tgz",
+      "integrity": "sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
+      "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -7003,6 +7101,45 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -7751,6 +7888,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/stable-hash": {
@@ -9165,6 +9311,15 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
     },
     "node_modules/yaml": {
       "version": "2.8.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "next-mdx-remote": "^4.4.1",
     "next-seo": "^6.8.0",
     "next-sitemap": "^4.2.3",
+    "pg": "^8.16.3",
     "postcss": "^8.5.6",
     "rate-limiter-flexible": "^7.3.1",
     "react": "18.3.1",
@@ -38,6 +39,7 @@
   },
   "devDependencies": {
     "@testing-library/react": "^16.3.0",
+    "@types/bcryptjs": "^2.4.6",
     "@types/formidable": "^3.4.5",
     "@types/negotiator": "^0.6.4",
     "@types/node": "^20.19.8",

--- a/pages/api/admin/login.ts
+++ b/pages/api/admin/login.ts
@@ -1,0 +1,334 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import crypto from 'crypto'
+import { Pool } from 'pg'
+import bcrypt from 'bcryptjs'
+
+import { createAdminSessionCookie } from '../../../src/lib/auth/session'
+import { logAuditEvent } from '../../../src/lib/logging/audit'
+import { consumeLoginRateLimit } from '../../../src/lib/security/rateLimit'
+
+interface LoginRequestBody {
+  username?: unknown
+  password?: unknown
+}
+
+interface SuccessResponse {
+  ok: true
+}
+
+interface ErrorResponse {
+  error: string
+}
+
+type ResponseBody = SuccessResponse | ErrorResponse
+
+const GENERIC_AUTH_ERROR = 'Invalid username or password'
+const RATE_LIMIT_ERROR = 'Too many login attempts. Please try again later.'
+const INTERNAL_ERROR = 'Unable to process login right now'
+
+const DUMMY_BCRYPT_HASH = bcrypt.hashSync('admin-login-dummy-password', 10)
+
+let cachedPool: Pool | null = null
+
+function parseBooleanFlag(value: string | undefined | null): boolean {
+  if (!value) return false
+  const normalized = value.trim().toLowerCase()
+  return ['1', 'true', 't', 'yes', 'y', 'on'].includes(normalized)
+}
+
+function isDatabaseAuthEnabled(): boolean {
+  return parseBooleanFlag(
+    process.env.ADMIN_DB_AUTH_ENABLED ?? process.env.ADMIN_DB_AUTH ?? undefined
+  )
+}
+
+function shouldUseDatabaseSsl(): boolean {
+  return parseBooleanFlag(
+    process.env.ADMIN_DB_SSL ?? process.env.DATABASE_SSL ?? undefined
+  )
+}
+
+function getDatabaseConnectionString(): string {
+  const connectionString =
+    process.env.ADMIN_DB_URL ?? process.env.DATABASE_URL ?? undefined
+  if (!connectionString) {
+    throw new Error(
+      'Database authentication is enabled but no connection string is configured'
+    )
+  }
+  return connectionString
+}
+
+function getPool(): Pool {
+  if (cachedPool) {
+    return cachedPool
+  }
+  const connectionString = getDatabaseConnectionString()
+  const useSsl = shouldUseDatabaseSsl()
+  cachedPool = new Pool({
+    connectionString,
+    ssl: useSsl ? { rejectUnauthorized: false } : undefined,
+  })
+  cachedPool.on('error', (error) => {
+    console.error('Unexpected admin database error', error)
+  })
+  return cachedPool
+}
+
+function getClientIp(req: NextApiRequest): string {
+  const forwarded = req.headers['x-forwarded-for']
+  if (typeof forwarded === 'string' && forwarded.length > 0) {
+    const [first] = forwarded.split(',')
+    if (first?.trim()) return first.trim()
+  }
+  if (Array.isArray(forwarded) && forwarded.length > 0) {
+    const [first] = forwarded[0].split(',')
+    if (first?.trim()) return first.trim()
+  }
+  return req.socket?.remoteAddress ?? 'unknown'
+}
+
+function constantTimeEquals(a: string, b: string): boolean {
+  const bufA = Buffer.from(a, 'utf8')
+  const bufB = Buffer.from(b, 'utf8')
+  const len = Math.max(bufA.length, bufB.length)
+  const paddedA = Buffer.alloc(len)
+  const paddedB = Buffer.alloc(len)
+  bufA.copy(paddedA)
+  bufB.copy(paddedB)
+  try {
+    return crypto.timingSafeEqual(paddedA, paddedB) && bufA.length === bufB.length
+  } catch {
+    return false
+  }
+}
+
+function isValueExplicitlyFalse(value: unknown): boolean {
+  if (value === null || value === undefined) return false
+  if (typeof value === 'boolean') return value === false
+  if (typeof value === 'number') return value === 0
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase()
+    return ['0', 'false', 'f', 'no', 'inactive', 'disabled'].includes(normalized)
+  }
+  return false
+}
+
+function extractPasswordHash(row: Record<string, unknown>): string | null {
+  const possibleKeys = ['password_hash', 'passwordHash', 'hash', 'password']
+  for (const key of possibleKeys) {
+    const value = row[key]
+    if (typeof value === 'string' && value.length > 0) {
+      return value
+    }
+  }
+  return null
+}
+
+function comparePassword(password: string, hash: string): Promise<boolean> {
+  return new Promise((resolve, reject) => {
+    bcrypt.compare(password, hash, (error, result) => {
+      if (error) {
+        reject(error)
+        return
+      }
+      resolve(Boolean(result))
+    })
+  })
+}
+
+async function verifyWithDatabase(
+  username: string,
+  password: string
+): Promise<string | null> {
+  const pool = getPool()
+  const table = process.env.ADMIN_DB_TABLE ?? 'admin_users'
+  const usernameColumn = process.env.ADMIN_DB_USERNAME_COLUMN ?? 'username'
+  const passwordColumn =
+    process.env.ADMIN_DB_PASSWORD_HASH_COLUMN ?? 'password_hash'
+  const activeColumn = process.env.ADMIN_DB_ACTIVE_COLUMN
+
+  const selectColumns = [
+    `${usernameColumn} AS username`,
+    `${passwordColumn} AS password_hash`,
+  ]
+  if (activeColumn) {
+    selectColumns.push(`${activeColumn} AS is_active`)
+  }
+
+  const query = `SELECT ${selectColumns.join(', ')} FROM ${table} WHERE ${usernameColumn} = $1 LIMIT 1`
+
+  const result = await pool.query(query, [username])
+  if (result.rows.length === 0) {
+    await comparePassword(password, DUMMY_BCRYPT_HASH)
+    return null
+  }
+
+  const row = result.rows[0] as Record<string, unknown>
+  const passwordHash = extractPasswordHash(row)
+  if (!passwordHash) {
+    await comparePassword(password, DUMMY_BCRYPT_HASH)
+    return null
+  }
+
+  if (activeColumn) {
+    const activeValue = row.is_active ?? row.active ?? row.enabled
+    if (isValueExplicitlyFalse(activeValue)) {
+      await comparePassword(password, DUMMY_BCRYPT_HASH)
+      return null
+    }
+  }
+
+  const passwordMatches = await comparePassword(password, passwordHash)
+  if (!passwordMatches) {
+    return null
+  }
+
+  const canonicalUsername =
+    typeof row.username === 'string' && row.username.length > 0
+      ? row.username
+      : username
+  return canonicalUsername
+}
+
+async function verifyWithEnv(
+  username: string,
+  password: string
+): Promise<string | null> {
+  const expectedUser = process.env.ADMIN_USER
+  if (!expectedUser) {
+    return null
+  }
+
+  const expectedHash = process.env.ADMIN_HASH
+  const expectedPassword = process.env.ADMIN_PASSWORD
+
+  const usernameMatches = constantTimeEquals(username, expectedUser)
+
+  if (expectedHash) {
+    const passwordMatches = await comparePassword(password, expectedHash)
+    if (usernameMatches && passwordMatches) {
+      return expectedUser
+    }
+    return null
+  }
+
+  if (typeof expectedPassword === 'string' && expectedPassword.length > 0) {
+    const passwordMatches = constantTimeEquals(password, expectedPassword)
+    if (usernameMatches && passwordMatches) {
+      return expectedUser
+    }
+  }
+
+  return null
+}
+
+async function verifyCredentials(
+  username: string,
+  password: string
+): Promise<string | null> {
+  if (isDatabaseAuthEnabled()) {
+    return verifyWithDatabase(username, password)
+  }
+  return verifyWithEnv(username, password)
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<ResponseBody>
+) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST')
+    res.status(405).json({ error: 'Method not allowed' })
+    return
+  }
+
+  res.setHeader('Cache-Control', 'no-store, max-age=0')
+
+  const clientIp = getClientIp(req)
+  const rateLimitRes = await consumeLoginRateLimit(clientIp)
+  if (rateLimitRes) {
+    const retryAfterSeconds = Math.ceil(rateLimitRes.msBeforeNext / 1000)
+    res.setHeader('Retry-After', String(retryAfterSeconds))
+    await logAuditEvent({
+      actor: 'unknown',
+      action: 'admin_login',
+      result: 'failure',
+      ip: clientIp,
+      reason: 'rate_limited',
+      details: { msBeforeNext: rateLimitRes.msBeforeNext },
+    })
+    res.status(429).json({ error: RATE_LIMIT_ERROR })
+    return
+  }
+
+  const body = (req.body ?? {}) as LoginRequestBody
+  const usernameRaw =
+    typeof body.username === 'string' ? body.username.trim() : ''
+  const passwordRaw = typeof body.password === 'string' ? body.password : ''
+
+  if (!usernameRaw || !passwordRaw) {
+    await logAuditEvent({
+      actor: usernameRaw || 'unknown',
+      action: 'admin_login',
+      result: 'failure',
+      ip: clientIp,
+      reason: 'invalid_request',
+    })
+    res.status(400).json({ error: GENERIC_AUTH_ERROR })
+    return
+  }
+
+  try {
+    const verifiedUsername = await verifyCredentials(usernameRaw, passwordRaw)
+    if (!verifiedUsername) {
+      await logAuditEvent({
+        actor: usernameRaw,
+        action: 'admin_login',
+        result: 'failure',
+        ip: clientIp,
+        reason: 'invalid_credentials',
+      })
+      res.status(401).json({ error: GENERIC_AUTH_ERROR })
+      return
+    }
+
+    let sessionCookie: ReturnType<typeof createAdminSessionCookie>
+    try {
+      sessionCookie = createAdminSessionCookie(verifiedUsername)
+    } catch (error) {
+      console.error('Failed to create admin session cookie', error)
+      await logAuditEvent({
+        actor: verifiedUsername,
+        action: 'admin_login',
+        result: 'failure',
+        ip: clientIp,
+        reason: 'session_error',
+      })
+      res.status(500).json({ error: INTERNAL_ERROR })
+      return
+    }
+
+    res.setHeader('Set-Cookie', sessionCookie.cookie)
+
+    await logAuditEvent({
+      actor: verifiedUsername,
+      action: 'admin_login',
+      result: 'success',
+      ip: clientIp,
+      details: { expiresAt: sessionCookie.payload.expiresAt },
+    })
+
+    res.status(200).json({ ok: true })
+  } catch (error) {
+    console.error('Admin login attempt failed', error)
+    await logAuditEvent({
+      actor: usernameRaw,
+      action: 'admin_login',
+      result: 'failure',
+      ip: clientIp,
+      reason: 'internal_error',
+    })
+    res.status(500).json({ error: INTERNAL_ERROR })
+  }
+}

--- a/src/lib/security/rateLimit.ts
+++ b/src/lib/security/rateLimit.ts
@@ -8,9 +8,45 @@ const uploadRateLimiter = new RateLimiterMemory({
   duration: Number.isFinite(duration) && duration > 0 ? duration : 60,
 });
 
+const loginPoints = Number.parseInt(
+  process.env.LOGIN_RATE_LIMIT_POINTS ?? '5',
+  10
+);
+const loginDurationSeconds = Number.parseInt(
+  process.env.LOGIN_RATE_LIMIT_DURATION ?? `${15 * 60}`,
+  10
+);
+
+const normalizedLoginPoints =
+  Number.isFinite(loginPoints) && loginPoints > 0 ? loginPoints : 5;
+const normalizedLoginDuration =
+  Number.isFinite(loginDurationSeconds) && loginDurationSeconds > 0
+    ? loginDurationSeconds
+    : 15 * 60;
+
+const loginRateLimiter = new RateLimiterMemory({
+  points: normalizedLoginPoints,
+  duration: normalizedLoginDuration,
+  blockDuration: normalizedLoginDuration,
+});
+
 export async function consumeUploadRateLimit(key: string): Promise<RateLimiterRes | null> {
   try {
     await uploadRateLimiter.consume(key);
+    return null;
+  } catch (error) {
+    if (error instanceof RateLimiterRes) {
+      return error;
+    }
+    throw error;
+  }
+}
+
+export async function consumeLoginRateLimit(
+  key: string
+): Promise<RateLimiterRes | null> {
+  try {
+    await loginRateLimiter.consume(key);
     return null;
   } catch (error) {
     if (error instanceof RateLimiterRes) {


### PR DESCRIPTION
## Summary
- add an admin login API that authenticates against the database when enabled or the existing environment variables otherwise, rate limits attempts, and logs outcomes
- extend the session helper to mint signed cookies configurable via environment variables so logins work for both database and fallback modes
- introduce a dedicated login rate limiter, document the optional database env vars, and add the pg and @types/bcryptjs dependencies

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c97dfd1c08832ba07aed4391074547