### PR TITLE
Wrap updateRates invocation in try/catch

### DIFF
--- a/scripts/update-rates.ts
+++ b/scripts/update-rates.ts
@@ -1,3 +1,12 @@
 import { updateRates } from '../src/lib/fx/updateRates';
 
-updateRates();
+async function main(): Promise<void> {
+  try {
+    await updateRates();
+  } catch (err) {
+    console.warn('Skipping rate update:', err);
+    process.exit(0);
+  }
+}
+
+void main();


### PR DESCRIPTION
## Summary
- wrap the updateRates script entrypoint in an async main function with try/catch handling
- log skipped updates and exit cleanly with code 0 when updateRates throws

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca12d280f8832b9f674e5532803475