### PR TITLE
Enhance admin CSRF protection and client handling

### DIFF
--- a/pages/api/admin/build-index.ts
+++ b/pages/api/admin/build-index.ts
@@ -1,9 +1,27 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { getAdminSessionFromCookies } from '@/src/lib/auth/session';
+import { parseCookies } from '@/src/lib/http/cookies';
+import { isValidCsrfToken } from '@/src/lib/security/csrf';
+import { ADMIN_CSRF_HEADER_NAME } from '@/src/lib/security/csrfConstants';
 import { buildIndexes } from '../../../src/lib/search/indexBuilder';
+
+const GENERIC_CSRF_ERROR = 'Invalid request';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
     res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const cookies = parseCookies(req.headers.cookie);
+  const session = getAdminSessionFromCookies(cookies);
+  if (!session) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+
+  if (!isValidCsrfToken(session, cookies, req.headers[ADMIN_CSRF_HEADER_NAME])) {
+    res.status(403).json({ error: GENERIC_CSRF_ERROR });
     return;
   }
   await buildIndexes();

--- a/pages/api/admin/properties.ts
+++ b/pages/api/admin/properties.ts
@@ -1,7 +1,13 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import fs from 'fs/promises';
 import path from 'path';
+import { getAdminSessionFromCookies } from '@/src/lib/auth/session';
+import { parseCookies } from '@/src/lib/http/cookies';
+import { isValidCsrfToken } from '@/src/lib/security/csrf';
+import { ADMIN_CSRF_HEADER_NAME } from '@/src/lib/security/csrfConstants';
 import { buildIndexes } from '../../../src/lib/search/indexBuilder';
+
+const GENERIC_CSRF_ERROR = 'Invalid request';
 
 interface RequestBody {
   type: string;
@@ -28,6 +34,16 @@ function priceBucket(price: number) {
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
     res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+  const cookies = parseCookies(req.headers.cookie);
+  const session = getAdminSessionFromCookies(cookies);
+  if (!session) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+  if (!isValidCsrfToken(session, cookies, req.headers[ADMIN_CSRF_HEADER_NAME])) {
+    res.status(403).json({ error: GENERIC_CSRF_ERROR });
     return;
   }
   const body: RequestBody = req.body;

--- a/src/lib/security/adminCsrf.ts
+++ b/src/lib/security/adminCsrf.ts
@@ -1,0 +1,111 @@
+import { useEffect, useState } from 'react';
+import {
+  ADMIN_CSRF_HEADER_NAME,
+  ADMIN_CSRF_STORAGE_KEY,
+  ADMIN_CSRF_TOKEN_COOKIE_NAME,
+} from './csrfConstants';
+
+function readCookie(name: string): string | null {
+  if (typeof document === 'undefined') {
+    return null;
+  }
+  const pattern = `${name}=`;
+  const cookies = document.cookie ? document.cookie.split(';') : [];
+  for (const cookie of cookies) {
+    const trimmed = cookie.trim();
+    if (trimmed.startsWith(pattern)) {
+      const value = trimmed.slice(pattern.length);
+      try {
+        return decodeURIComponent(value);
+      } catch {
+        return value;
+      }
+    }
+  }
+  return null;
+}
+
+export function persistAdminCsrfToken(token: string): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  try {
+    window.localStorage.setItem(ADMIN_CSRF_STORAGE_KEY, token);
+  } catch {
+    // Ignore persistence errors (e.g., storage disabled)
+  }
+}
+
+export function getStoredAdminCsrfToken(): string | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  try {
+    return window.localStorage.getItem(ADMIN_CSRF_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function readAdminCsrfToken(): string | null {
+  const cookieToken = readCookie(ADMIN_CSRF_TOKEN_COOKIE_NAME);
+  if (cookieToken) {
+    persistAdminCsrfToken(cookieToken);
+    return cookieToken;
+  }
+  return getStoredAdminCsrfToken();
+}
+
+export function useAdminCsrfToken(): string | null {
+  const [token, setToken] = useState<string | null>(() => {
+    if (typeof window === 'undefined') {
+      return null;
+    }
+    return readAdminCsrfToken();
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    const nextToken = readAdminCsrfToken();
+    if (nextToken) {
+      setToken(nextToken);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    const handler = () => {
+      const nextToken = readAdminCsrfToken();
+      if (nextToken) {
+        setToken(nextToken);
+      }
+    };
+    window.addEventListener('focus', handler);
+    return () => {
+      window.removeEventListener('focus', handler);
+    };
+  }, []);
+
+  return token;
+}
+
+export function withAdminCsrfHeader(
+  headers: HeadersInit | undefined,
+  token: string | null
+): HeadersInit | undefined {
+  if (!token) {
+    return headers;
+  }
+  if (headers instanceof Headers) {
+    headers.set(ADMIN_CSRF_HEADER_NAME, token);
+    return headers;
+  }
+  if (Array.isArray(headers)) {
+    return [...headers, [ADMIN_CSRF_HEADER_NAME, token]];
+  }
+  return { ...headers, [ADMIN_CSRF_HEADER_NAME]: token };
+}

--- a/src/lib/security/csrf.ts
+++ b/src/lib/security/csrf.ts
@@ -1,32 +1,48 @@
 import crypto from 'crypto';
 import type { CookieMap } from '../http/cookies';
+import type { AdminSession } from '../auth/session';
+import { ADMIN_CSRF_COOKIE_NAME } from './csrfConstants';
 
 export interface CsrfValidationOptions {
   cookieName?: string;
 }
 
+function constantTimeEquals(expected: string, provided: string): boolean {
+  try {
+    const expectedBuffer = Buffer.from(expected, 'utf8');
+    const providedBuffer = Buffer.from(provided, 'utf8');
+    if (expectedBuffer.length !== providedBuffer.length) {
+      return false;
+    }
+    return crypto.timingSafeEqual(expectedBuffer, providedBuffer);
+  } catch {
+    return false;
+  }
+}
+
 export function isValidCsrfToken(
+  session: AdminSession | null,
   cookies: CookieMap,
   headerValue: string | string[] | undefined,
   options: CsrfValidationOptions = {}
 ): boolean {
-  const cookieName = options.cookieName ?? 'csrf_token';
-  const tokenFromCookie = cookies[cookieName];
+  if (!session || typeof session.csrfToken !== 'string' || session.csrfToken.length === 0) {
+    return false;
+  }
+
   const headerToken = Array.isArray(headerValue) ? headerValue[0] : headerValue;
-
-  if (!tokenFromCookie || typeof headerToken !== 'string' || headerToken.length === 0) {
+  if (typeof headerToken !== 'string' || headerToken.length === 0) {
     return false;
   }
 
-  if (tokenFromCookie.length !== headerToken.length) {
+  const cookieName = options.cookieName ?? ADMIN_CSRF_COOKIE_NAME;
+  const cookieToken = cookies[cookieName];
+  if (typeof cookieToken !== 'string' || cookieToken.length === 0) {
     return false;
   }
 
-  try {
-    const cookieBuffer = Buffer.from(tokenFromCookie, 'utf8');
-    const headerBuffer = Buffer.from(headerToken, 'utf8');
-    return crypto.timingSafeEqual(cookieBuffer, headerBuffer);
-  } catch {
-    return false;
-  }
+  return (
+    constantTimeEquals(session.csrfToken, headerToken) &&
+    constantTimeEquals(session.csrfToken, cookieToken)
+  );
 }

--- a/src/lib/security/csrfConstants.ts
+++ b/src/lib/security/csrfConstants.ts
@@ -1,0 +1,4 @@
+export const ADMIN_CSRF_COOKIE_NAME = 'admin_csrf';
+export const ADMIN_CSRF_TOKEN_COOKIE_NAME = 'admin_csrf_token';
+export const ADMIN_CSRF_HEADER_NAME = 'x-csrf';
+export const ADMIN_CSRF_STORAGE_KEY = 'admin.csrf.token';


### PR DESCRIPTION
## Summary
- persist a per-session CSRF token, set dedicated cookies during admin login, and expose token details
- validate admin POST APIs against the stored CSRF token and require authenticated sessions
- add client-side helpers so admin tools capture the issued token and send it with protected requests

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca1da8b204832b8c029a9a2ddaf5ba