### PR TITLE
Refactor search index format and loaders

### DIFF
--- a/pages/api/search.ts
+++ b/pages/api/search.ts
@@ -6,6 +6,8 @@ import { searchParamsSchema, type SearchParams } from '../../src/lib/validation/
 import type { ProcessedImage } from '../../src/components/PropertyImage';
 import { applyFilters, sortResults } from '../../src/lib/search/shared';
 
+type Locale = 'en' | 'th' | 'zh';
+
 interface PropertyDTO {
   id: number;
   title: { en: string; th: string; zh?: string };
@@ -30,10 +32,102 @@ interface SearchResponse {
   results: PropertyDTO[];
 }
 
-const indexCache: Record<string, MiniSearch<any>> = {};
+interface SearchDoc {
+  id: number;
+  province: string;
+  province_th: string;
+  type: string;
+  title_en: string;
+  title_th: string;
+  title_zh: string;
+  description_en: string;
+  description_th: string;
+  description_zh: string;
+  price: number;
+  priceBucket: string;
+  amenities: string[];
+  images: string[];
+  createdAt: string;
+  beds?: number;
+  baths?: number;
+  status?: string;
+  pricePerSqm?: number;
+  areaBuilt?: number;
+  nearTransit?: boolean;
+  furnished?: string;
+  transitLine?: string;
+  transitStation?: string;
+}
+
+interface ModernShard {
+  docs: SearchDoc[];
+  docMap: Map<number, SearchDoc>;
+  indexes: Partial<Record<Locale, MiniSearch<SearchDoc>>>;
+}
+
+interface LegacyShard {
+  legacy: true;
+  index: MiniSearch<any>;
+}
+
+type LoadedShard = ModernShard | LegacyShard;
+
+const shardCache: Record<string, LoadedShard> = {};
 let manifest: { shards: { key: string; province: string; type: string }[] } | null = null;
 let amenitiesList: string[] | null = null;
 let transitMap: Record<string, string[]> | null = null;
+
+const MODERN_FIELDS: Record<Locale, (keyof SearchDoc)[]> = {
+  en: ['title_en', 'description_en'],
+  th: ['title_th', 'description_th'],
+  zh: ['title_zh', 'description_zh'],
+};
+
+const LEGACY_OPTIONS = {
+  fields: [
+    'title_en',
+    'title_th',
+    'title_zh',
+    'description_en',
+    'description_th',
+    'description_zh',
+  ],
+  storeFields: [
+    'id',
+    'title_en',
+    'title_th',
+    'title_zh',
+    'province',
+    'province_th',
+    'type',
+    'price',
+    'priceBucket',
+    'amenities',
+    'images',
+    'createdAt',
+    'beds',
+    'baths',
+    'status',
+    'pricePerSqm',
+    'areaBuilt',
+    'description_en',
+    'description_th',
+    'description_zh',
+  ],
+} as const;
+
+function isLegacyShard(shard: LoadedShard): shard is LegacyShard {
+  return 'legacy' in shard && shard.legacy;
+}
+
+function localePriority(locale?: string): Locale[] {
+  const bases: Locale[] = ['en', 'th', 'zh'];
+  if (!locale) return bases;
+  const lower = locale.toLowerCase();
+  if (!['en', 'th', 'zh'].includes(lower)) return bases;
+  const preferred = lower as Locale;
+  return [preferred, ...bases.filter((loc) => loc !== preferred)];
+}
 
 async function loadManifest() {
   if (!manifest) {
@@ -43,44 +137,35 @@ async function loadManifest() {
   return manifest!;
 }
 
-async function loadIndex(key: string) {
-  if (!indexCache[key]) {
+async function loadShard(key: string): Promise<LoadedShard> {
+  if (!shardCache[key]) {
     const file = await fs.readFile(path.join(process.cwd(), 'public', 'data', 'index', `${key}.json`), 'utf-8');
     const json = JSON.parse(file);
-    indexCache[key] = MiniSearch.loadJSON(json, {
-      fields: [
-        'title_en',
-        'title_th',
-        'title_zh',
-        'description_en',
-        'description_th',
-        'description_zh',
-      ],
-      storeFields: [
-        'id',
-        'title_en',
-        'title_th',
-        'title_zh',
-        'province',
-        'province_th',
-        'type',
-        'price',
-        'priceBucket',
-        'amenities',
-        'images',
-        'createdAt',
-        'beds',
-        'baths',
-        'status',
-        'pricePerSqm',
-        'areaBuilt',
-        'description_en',
-        'description_th',
-        'description_zh',
-      ],
-    });
+    if (json && typeof json === 'object' && 'indexes' in json && 'docs' in json) {
+      const docs: SearchDoc[] = Array.isArray(json.docs) ? json.docs : [];
+      const docMap = new Map<number, SearchDoc>();
+      for (const doc of docs) {
+        docMap.set(doc.id, doc);
+      }
+      const indexes: Partial<Record<Locale, MiniSearch<SearchDoc>>> = {};
+      (Object.keys(MODERN_FIELDS) as Locale[]).forEach((locale) => {
+        const indexJson = json.indexes?.[locale];
+        if (indexJson) {
+          indexes[locale] = MiniSearch.loadJSON(indexJson, {
+            fields: MODERN_FIELDS[locale],
+            storeFields: ['id'],
+          });
+        }
+      });
+      shardCache[key] = { docs, docMap, indexes };
+    } else {
+      shardCache[key] = {
+        legacy: true,
+        index: MiniSearch.loadJSON(json, LEGACY_OPTIONS),
+      };
+    }
   }
-  return indexCache[key];
+  return shardCache[key];
 }
 
 async function loadAmenities() {
@@ -114,7 +199,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     res.status(400).json({ error: 'Invalid search parameters' });
     return;
   }
-  const params = parsed.data;
+  const params = parsed.data as SearchParams & { locale?: string };
 
   const [amenities, transit] = await Promise.all([
     loadAmenities(),
@@ -138,11 +223,77 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return (!params.province || s.province === params.province) && (!params.type || s.type === params.type);
   });
 
-  const matches: any[] = [];
-  for (const shard of shards) {
-    const index = await loadIndex(shard.key);
-    const resu = index.search(params.query || '', { prefix: true });
-    matches.push(...resu.map((r) => r));
+  const matches: SearchDoc[] = [];
+  const seen = new Set<number>();
+  const query = params.query?.trim() ?? '';
+  const priorities = localePriority(params.locale);
+  for (const shardInfo of shards) {
+    const shard = await loadShard(shardInfo.key);
+    if (isLegacyShard(shard)) {
+      const resu = shard.index.search(query, { prefix: true, fuzzy: 0.2 });
+      for (const r of resu) {
+        const id = typeof r.id === 'number' ? r.id : Number(r.id);
+        if (!Number.isFinite(id) || seen.has(id)) continue;
+        matches.push(r as SearchDoc);
+        seen.add(id);
+      }
+      if (!query) {
+        const store = (shard.index as any).documentStore;
+        const docs = store ? Object.values(store.docs || {}) : [];
+        for (const entry of docs) {
+          const value = entry?.store;
+          const docId = value?.id;
+          const numericId = typeof docId === 'number' ? docId : Number(docId);
+          if (!value || !Number.isFinite(numericId) || seen.has(numericId)) continue;
+          matches.push(value as SearchDoc);
+          seen.add(numericId);
+        }
+      }
+      continue;
+    }
+
+    if (!query) {
+      for (const doc of shard.docs) {
+        if (!seen.has(doc.id)) {
+          matches.push(doc);
+          seen.add(doc.id);
+        }
+      }
+      continue;
+    }
+
+    for (const locale of priorities) {
+      const index = shard.indexes[locale];
+      if (!index) continue;
+      const resu = index.search(query, { prefix: true, fuzzy: 0.2 });
+      for (const r of resu) {
+        const docId = typeof r.id === 'number' ? r.id : Number(r.id);
+        if (!Number.isFinite(docId) || seen.has(docId)) continue;
+        const doc = shard.docMap.get(docId);
+        if (doc) {
+          matches.push(doc);
+          seen.add(doc.id);
+        }
+      }
+    }
+  }
+
+  if (params.minPrice !== undefined) {
+    if (!isValidPrice(params.minPrice) || params.minPrice < MIN_PRICE) {
+      params.minPrice = MIN_PRICE;
+    }
+  }
+  if (params.maxPrice !== undefined) {
+    if (!isValidPrice(params.maxPrice) || params.maxPrice > MAX_PRICE) {
+      params.maxPrice = MAX_PRICE;
+    }
+  }
+  if (
+    params.minPrice !== undefined &&
+    params.maxPrice !== undefined &&
+    params.minPrice > params.maxPrice
+  ) {
+    [params.minPrice, params.maxPrice] = [params.maxPrice, params.minPrice];
   }
 
   const filtered = applyFilters(matches, params);
@@ -152,7 +303,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const start = (page - 1) * pageSize;
   const paginated = sorted.slice(start, start + pageSize);
 
-  const results: PropertyDTO[] = paginated.map((doc: any) => ({
+  const results: PropertyDTO[] = paginated.map((doc: SearchDoc) => ({
     id: doc.id,
     title: { en: doc.title_en, th: doc.title_th, zh: doc.title_zh },
     province: { en: doc.province, th: doc.province_th },
@@ -174,4 +325,3 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const response: SearchResponse = { total: filtered.length, results };
   res.status(200).json(response);
 }
-

--- a/pages/api/suggest.ts
+++ b/pages/api/suggest.ts
@@ -1,18 +1,83 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import fs from 'fs';
+import fs from 'fs/promises';
 import path from 'path';
 
-/**
- * Returns search suggestions for the site.
- *
- * Responds with HTTP 500 if the suggestions file cannot be read.
- */
+type Locale = 'en' | 'th' | 'zh';
+
+interface SuggestionRecord {
+  canonical: string;
+  locales?: Partial<Record<Locale, string>>;
+}
+
+function normalizeLocale(input?: string | string[]): Locale | undefined {
+  const value = Array.isArray(input) ? input[0] : input;
+  if (!value) return undefined;
+  const lower = value.toLowerCase();
+  if (lower.startsWith('en')) return 'en';
+  if (lower.startsWith('th')) return 'th';
+  if (lower.startsWith('zh')) return 'zh';
+  return undefined;
+}
+
+function detectLocale(req: NextApiRequest): Locale | undefined {
+  return (
+    normalizeLocale(req.query.locale) ||
+    normalizeLocale(req.cookies?.NEXT_LOCALE) ||
+    normalizeLocale(req.headers['accept-language'])
+  );
+}
+
+function parseQuery(q: string | string[] | undefined) {
+  if (!q) return '';
+  return Array.isArray(q) ? q[0]?.trim() ?? '' : q.trim();
+}
+
+function asSuggestionRecords(raw: any): SuggestionRecord[] | null {
+  if (!raw || typeof raw !== 'object') return null;
+  if (!('suggestions' in raw)) return null;
+  const list = (raw as any).suggestions;
+  if (Array.isArray(list) && list.every((item) => typeof item === 'string')) {
+    return (list as string[]).map((canonical) => ({ canonical, locales: { en: canonical } }));
+  }
+  if (Array.isArray(list)) {
+    return list.filter((entry) => typeof entry?.canonical === 'string');
+  }
+  return null;
+}
+
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const filePath = path.join(process.cwd(), 'public', 'data', 'index', 'suggest.json');
   try {
-    const fileContents = await fs.promises.readFile(filePath, 'utf-8');
-    const data = JSON.parse(fileContents);
-    res.status(200).json(data);
+    const fileContents = await fs.readFile(filePath, 'utf-8');
+    const parsed = JSON.parse(fileContents);
+    const suggestions = asSuggestionRecords(parsed) ?? [];
+    const locale = detectLocale(req) ?? 'en';
+    const query = parseQuery(req.query.q).toLowerCase();
+
+    const unique = new Set<string>();
+    const results: string[] = [];
+
+    for (const entry of suggestions) {
+      if (results.length >= 10) break;
+      const localized = entry.locales?.[locale] ?? entry.locales?.en ?? entry.canonical;
+      if (!localized) continue;
+      const candidate = localized.trim();
+      if (!candidate) continue;
+      const canonical = entry.canonical?.toLowerCase?.() ?? '';
+      const candidateLower = candidate.toLowerCase();
+      if (
+        query &&
+        !(candidateLower.startsWith(query) || (canonical && canonical.startsWith(query)))
+      ) {
+        continue;
+      }
+      const key = candidate.toLowerCase();
+      if (unique.has(key)) continue;
+      unique.add(key);
+      results.push(candidate);
+    }
+
+    res.status(200).json({ suggestions: results });
   } catch (err) {
     res.status(500).json({ error: 'Failed to load suggestions' });
   }

--- a/pages/properties.tsx
+++ b/pages/properties.tsx
@@ -29,7 +29,7 @@ export default function PropertySearchPage() {
       setResults(e.data.results)
       worker.terminate()
     }
-    worker.postMessage({ query: '', ...f })
+    worker.postMessage({ locale, query: '', ...f })
   }
 
   useEffect(() => {

--- a/src/lib/validation/search.ts
+++ b/src/lib/validation/search.ts
@@ -7,6 +7,7 @@ export const searchParamsSchema = z.object({
   query: safeString.optional(),
   province: safeString.optional(),
   type: safeString.optional(),
+  locale: z.enum(['en', 'th', 'zh']).optional(),
   minPrice: z
     .coerce
     .number()

--- a/src/workers/search.worker.ts
+++ b/src/workers/search.worker.ts
@@ -4,6 +4,8 @@ import { MIN_PRICE, MAX_PRICE, isValidPrice } from '../lib/filters/price';
 import type { ProcessedImage } from '../components/PropertyImage';
 import { applyFilters, sortResults } from '../lib/search/shared';
 
+type Locale = 'en' | 'th' | 'zh';
+
 interface PropertyDTO {
   id: number;
   title: { en: string; th: string; zh?: string };
@@ -28,10 +30,102 @@ interface SearchResponse {
   results: PropertyDTO[];
 }
 
-const indexCache: Record<string, MiniSearch<any>> = {};
+interface SearchDoc {
+  id: number;
+  province: string;
+  province_th: string;
+  type: string;
+  title_en: string;
+  title_th: string;
+  title_zh: string;
+  description_en: string;
+  description_th: string;
+  description_zh: string;
+  price: number;
+  priceBucket: string;
+  amenities: string[];
+  images: string[];
+  createdAt: string;
+  beds?: number;
+  baths?: number;
+  status?: string;
+  pricePerSqm?: number;
+  areaBuilt?: number;
+  nearTransit?: boolean;
+  furnished?: string;
+  transitLine?: string;
+  transitStation?: string;
+}
+
+interface ModernShard {
+  docs: SearchDoc[];
+  docMap: Map<number, SearchDoc>;
+  indexes: Partial<Record<Locale, MiniSearch<SearchDoc>>>;
+}
+
+interface LegacyShard {
+  legacy: true;
+  index: MiniSearch<any>;
+}
+
+type LoadedShard = ModernShard | LegacyShard;
+
+const shardCache: Record<string, LoadedShard> = {};
 let manifest: { shards: { key: string; province: string; type: string }[] } | null = null;
 let amenitiesList: string[] | null = null;
 let transitMap: Record<string, string[]> | null = null;
+
+const MODERN_FIELDS: Record<Locale, (keyof SearchDoc)[]> = {
+  en: ['title_en', 'description_en'],
+  th: ['title_th', 'description_th'],
+  zh: ['title_zh', 'description_zh'],
+};
+
+const LEGACY_OPTIONS = {
+  fields: [
+    'title_en',
+    'title_th',
+    'title_zh',
+    'description_en',
+    'description_th',
+    'description_zh',
+  ],
+  storeFields: [
+    'id',
+    'title_en',
+    'title_th',
+    'title_zh',
+    'province',
+    'province_th',
+    'type',
+    'price',
+    'priceBucket',
+    'amenities',
+    'images',
+    'createdAt',
+    'beds',
+    'baths',
+    'status',
+    'pricePerSqm',
+    'areaBuilt',
+    'description_en',
+    'description_th',
+    'description_zh',
+  ],
+} as const;
+
+function isLegacyShard(shard: LoadedShard): shard is LegacyShard {
+  return 'legacy' in shard && shard.legacy;
+}
+
+function localePriority(locale?: string): Locale[] {
+  const bases: Locale[] = ['en', 'th', 'zh'];
+  if (!locale) return bases;
+  const lower = locale.toLowerCase();
+  if (!['en', 'th', 'zh'].includes(lower)) return bases;
+  const preferred = lower as Locale;
+  return [preferred, ...bases.filter((loc) => loc !== preferred)];
+}
 
 async function loadManifest() {
   if (!manifest) {
@@ -41,44 +135,35 @@ async function loadManifest() {
   return manifest!;
 }
 
-async function loadIndex(key: string) {
-  if (!indexCache[key]) {
+async function loadShard(key: string): Promise<LoadedShard> {
+  if (!shardCache[key]) {
     const res = await fetch(`/data/index/${key}.json`);
     const json = await res.json();
-    indexCache[key] = MiniSearch.loadJSON(json, {
-      fields: [
-        'title_en',
-        'title_th',
-        'title_zh',
-        'description_en',
-        'description_th',
-        'description_zh',
-      ],
-      storeFields: [
-        'id',
-        'title_en',
-        'title_th',
-        'title_zh',
-        'province',
-        'province_th',
-        'type',
-        'price',
-        'priceBucket',
-        'amenities',
-        'images',
-        'createdAt',
-        'beds',
-        'baths',
-        'status',
-        'pricePerSqm',
-        'areaBuilt',
-        'description_en',
-        'description_th',
-        'description_zh',
-      ],
-    });
+    if (json && typeof json === 'object' && 'indexes' in json && 'docs' in json) {
+      const docs: SearchDoc[] = Array.isArray(json.docs) ? json.docs : [];
+      const docMap = new Map<number, SearchDoc>();
+      for (const doc of docs) {
+        docMap.set(doc.id, doc);
+      }
+      const indexes: Partial<Record<Locale, MiniSearch<SearchDoc>>> = {};
+      (Object.keys(MODERN_FIELDS) as Locale[]).forEach((locale) => {
+        const indexJson = json.indexes?.[locale];
+        if (indexJson) {
+          indexes[locale] = MiniSearch.loadJSON(indexJson, {
+            fields: MODERN_FIELDS[locale],
+            storeFields: ['id'],
+          });
+        }
+      });
+      shardCache[key] = { docs, docMap, indexes };
+    } else {
+      shardCache[key] = {
+        legacy: true,
+        index: MiniSearch.loadJSON(json, LEGACY_OPTIONS),
+      };
+    }
   }
-  return indexCache[key];
+  return shardCache[key];
 }
 
 async function loadAmenities() {
@@ -104,7 +189,7 @@ self.onmessage = async (event: MessageEvent<any>) => {
     (self as any).postMessage({ total: 0, results: [] });
     return;
   }
-  const req: SearchParams = parsed.data;
+  const req: (SearchParams & { locale?: string }) = parsed.data as any;
   const [amenities, transit] = await Promise.all([
     loadAmenities(),
     loadTransit(),
@@ -124,12 +209,59 @@ self.onmessage = async (event: MessageEvent<any>) => {
   const man = await loadManifest();
   const shards = man.shards;
 
-  const matches: any[] = [];
+  const matches: SearchDoc[] = [];
+  const seen = new Set<number>();
   const query = req.query?.trim() ?? '';
-  for (const shard of shards) {
-    const index = await loadIndex(shard.key);
-    const res = index.search(query, { prefix: true, fuzzy: 0.2 });
-    matches.push(...res.map((r) => r));
+  const priorities = localePriority(req.locale);
+  for (const shardInfo of shards) {
+    const shard = await loadShard(shardInfo.key);
+    if (isLegacyShard(shard)) {
+      const res = shard.index.search(query, { prefix: true, fuzzy: 0.2 });
+      for (const r of res) {
+        const id = typeof r.id === 'number' ? r.id : Number(r.id);
+        if (!Number.isFinite(id) || seen.has(id)) continue;
+        matches.push(r as SearchDoc);
+        seen.add(id);
+      }
+      if (!query) {
+        const store = (shard.index as any).documentStore;
+        const docs = store ? Object.values(store.docs || {}) : [];
+        for (const entry of docs) {
+          const value = entry?.store;
+          const docId = value?.id;
+          const numericId = typeof docId === 'number' ? docId : Number(docId);
+          if (!value || !Number.isFinite(numericId) || seen.has(numericId)) continue;
+          matches.push(value as SearchDoc);
+          seen.add(numericId);
+        }
+      }
+      continue;
+    }
+
+    if (!query) {
+      for (const doc of shard.docs) {
+        if (!seen.has(doc.id)) {
+          matches.push(doc);
+          seen.add(doc.id);
+        }
+      }
+      continue;
+    }
+
+    for (const locale of priorities) {
+      const index = shard.indexes[locale];
+      if (!index) continue;
+      const res = index.search(query, { prefix: true, fuzzy: 0.2 });
+      for (const r of res) {
+        const docId = typeof r.id === 'number' ? r.id : Number(r.id);
+        if (!Number.isFinite(docId) || seen.has(docId)) continue;
+        const doc = shard.docMap.get(docId);
+        if (doc) {
+          matches.push(doc);
+          seen.add(doc.id);
+        }
+      }
+    }
   }
 
   if (req.minPrice !== undefined) {
@@ -156,7 +288,7 @@ self.onmessage = async (event: MessageEvent<any>) => {
   const start = (page - 1) * pageSize;
   const paginated = sorted.slice(start, start + pageSize);
 
-  const results: PropertyDTO[] = paginated.map((doc: any) => ({
+  const results: PropertyDTO[] = paginated.map((doc: SearchDoc) => ({
     id: doc.id,
     title: { en: doc.title_en, th: doc.title_th, zh: doc.title_zh },
     province: { en: doc.province, th: doc.province_th },
@@ -172,7 +304,7 @@ self.onmessage = async (event: MessageEvent<any>) => {
     nearTransit: doc.nearTransit,
     furnished: doc.furnished,
     transitLine: doc.transitLine,
-    transitStation: doc.transitStation
+    transitStation: doc.transitStation,
   }));
 
   const response: SearchResponse = { total: filtered.length, results };


### PR DESCRIPTION
## Summary
- change search index builder to emit shard payloads with per-locale MiniSearch JSON and richer suggestion metadata
- update client worker and API search handler to load new shard format with locale-aware lookup while supporting legacy indexes
- refresh suggestions API to filter canonical suggestion data with localized output and add locale-aware search parameter handling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca2309ddec832bb34e236fba07a794