### PR TITLE
Adjust security and caching headers

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -19,14 +19,14 @@ const securityHeaders = [
   },
   {
     key: 'Permissions-Policy',
-    value: 'camera=(), microphone=(), geolocation=()',
+    value: 'geolocation=(), microphone=(), camera=()',
   },
 ]
 
 const indexCacheHeaders = [
   {
     key: 'Cache-Control',
-    value: 'public, max-age=31536000, immutable',
+    value: 'public, max-age=600, stale-while-revalidate=60',
   },
 ]
 


### PR DESCRIPTION
## Summary
- update the global Permissions-Policy header to list geolocation, microphone, and camera in the requested order
- change the /data/index/:path* Cache-Control directive to use a 10-minute max-age with stale-while-revalidate
- reviewed the codebase for additional header overrides and confirmed none affect these routes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca2706bb08832b9facb71e56e91b16