### PR TITLE
Adjust PropertyImage defaults and gallery keys

### DIFF
--- a/src/components/PropertyImage.tsx
+++ b/src/components/PropertyImage.tsx
@@ -9,6 +9,7 @@ export type ImgLike = string | { src: string } | ProcessedImage
 
 const DEFAULT_WIDTH = 600
 const DEFAULT_HEIGHT = 400
+const DEFAULT_SIZES = '100vw'
 
 const ensurePositiveInt = (value?: number): number | undefined => {
   if (typeof value !== 'number') return undefined
@@ -23,7 +24,13 @@ const placeholderSrc = (width?: number, height?: number): string => {
   return `https://placehold.co/${finalWidth}x${finalHeight}?text=Zomzom+Image`
 }
 
-export const asSrc = (img?: ImgLike, width?: number, height?: number): string => {
+export const asSrc = (
+  img?: ImgLike,
+  dimensions?: { width?: number; height?: number }
+): string => {
+  const width = dimensions?.width
+  const height = dimensions?.height
+
   if (!img) return placeholderSrc(width, height)
 
   if (typeof img === 'string') {
@@ -38,17 +45,34 @@ export const asSrc = (img?: ImgLike, width?: number, height?: number): string =>
 
 interface Props {
   src?: ImgLike
-  alt: string
+  alt?: string
   w?: number
   h?: number
   sizes?: string
+  className?: string
 }
 
-export default function PropertyImage({ src, alt, w, h, sizes }: Props) {
+export default function PropertyImage({
+  src,
+  alt,
+  w,
+  h,
+  sizes = DEFAULT_SIZES,
+  className = 'object-cover',
+}: Props) {
   const width = ensurePositiveInt(w) ?? DEFAULT_WIDTH
   const height = ensurePositiveInt(h) ?? DEFAULT_HEIGHT
-  const finalSrc = asSrc(src, width, height)
+  const finalSrc = asSrc(src, { width, height })
 
-  return <Image src={finalSrc} alt={alt} width={width} height={height} sizes={sizes} />
+  return (
+    <Image
+      src={finalSrc}
+      alt={alt ?? ''}
+      width={width}
+      height={height}
+      sizes={sizes}
+      className={className}
+    />
+  )
 }
 

--- a/src/views/properties/PropertyDetailPageContent.tsx
+++ b/src/views/properties/PropertyDetailPageContent.tsx
@@ -66,16 +66,13 @@ export default function PropertyDetailPageContent({
       )}
       <div>
         {(property.images ?? []).length > 0 ? (
-          (property.images ?? []).map((img, i) => {
-            const src = asSrc(img)
-            return (
-              <PropertyImage
-                key={src}
-                src={src}
-                alt={`${title} image ${i + 1}`}
-              />
-            )
-          })
+          (property.images ?? []).map((img, i) => (
+            <PropertyImage
+              key={`${asSrc(img)}-${i}`}
+              src={img}
+              alt={`${title} image ${i + 1}`}
+            />
+          ))
         ) : (
           <PropertyImage src={undefined} alt={`${title} placeholder`} />
         )}


### PR DESCRIPTION
## Summary
- update `PropertyImage` to accept optional alt text, apply default sizing/className, and extend the `asSrc` helper signature
- refactor the property detail gallery to use the revised component props with stable keys while relying on placeholder fallbacks

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca3028fccc832b96a7557557529dc7