### PR TITLE
Integrate admin UI with external API authentication

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -8,6 +8,7 @@ import { buildUrl } from "../lib/url";
 import defaultSeo from "../next-seo.config";
 import { CurrencyProvider } from "../src/context/CurrencyContext";
 import { AdminPreviewProvider } from "../src/context/AdminPreviewContext";
+import { AdminAuthProvider } from "../src/context/AdminAuthContext";
 import AdminPreviewBanner from "../components/AdminPreviewBanner";
 import { prompt, inter } from "../src/styles/fonts";
 import { useEffect, useRef, useState } from "react";
@@ -110,26 +111,28 @@ function MyApp({ Component, pageProps }: AppProps) {
       <DefaultSeo {...defaultSeo} />
       <JsonLd scriptId="organization-jsonld" {...orgJsonLd} />
       <JsonLd scriptId="website-jsonld" {...webSiteJsonLd} />
-      <AdminPreviewProvider>
-        <CurrencyProvider>
-          <div className="sticky top-0 z-50">
-            <AdminPreviewBanner />
-          </div>
-          <FloatingContacts />
-          <AnimatePresence mode="wait" initial={false}>
-            <motion.div
-              key={router.asPath}
-              variants={variants[variantKey]}
-              initial="hidden"
-              animate="enter"
-              exit="exit"
-              transition={{ type: "tween", duration: 0.2 }}
-            >
-              <Component {...pageProps} />
-            </motion.div>
-          </AnimatePresence>
-        </CurrencyProvider>
-      </AdminPreviewProvider>
+      <AdminAuthProvider>
+        <AdminPreviewProvider>
+          <CurrencyProvider>
+            <div className="sticky top-0 z-50">
+              <AdminPreviewBanner />
+            </div>
+            <FloatingContacts />
+            <AnimatePresence mode="wait" initial={false}>
+              <motion.div
+                key={router.asPath}
+                variants={variants[variantKey]}
+                initial="hidden"
+                animate="enter"
+                exit="exit"
+                transition={{ type: "tween", duration: 0.2 }}
+              >
+                <Component {...pageProps} />
+              </motion.div>
+            </AnimatePresence>
+          </CurrencyProvider>
+        </AdminPreviewProvider>
+      </AdminAuthProvider>
     </div>
   );
 }

--- a/src/components/admin/AdminLoginForm.tsx
+++ b/src/components/admin/AdminLoginForm.tsx
@@ -1,0 +1,90 @@
+import { FormEvent, useEffect, useState } from 'react'
+
+import { useAdminAuth } from '@/src/context/AdminAuthContext'
+
+interface Props {
+  title?: string
+  description?: string
+}
+
+export default function AdminLoginForm({
+  title = 'Admin login',
+  description = 'Sign in with your workspace credentials to continue.',
+}: Props) {
+  const { login, isLoading, error, clearError } = useAdminAuth()
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [localError, setLocalError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (error) {
+      setLocalError(error)
+    }
+  }, [error])
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setLocalError(null)
+    clearError()
+    try {
+      await login(username.trim(), password)
+      setPassword('')
+    } catch (err: any) {
+      if (typeof err?.message === 'string') {
+        setLocalError(err.message)
+      } else if (!localError) {
+        setLocalError('Login failed. Please check your credentials.')
+      }
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-slate-100 px-4 py-12">
+      <div className="w-full max-w-md rounded-lg bg-white p-8 shadow-xl">
+        <h1 className="text-2xl font-semibold text-slate-900">{title}</h1>
+        <p className="mt-2 text-sm text-slate-600">{description}</p>
+        <form onSubmit={handleSubmit} className="mt-6 space-y-4">
+          <div>
+            <label htmlFor="admin-username" className="text-sm font-medium text-slate-700">
+              Username
+            </label>
+            <input
+              id="admin-username"
+              name="username"
+              value={username}
+              onChange={(event) => setUsername(event.target.value)}
+              className="mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-slate-500 focus:outline-none"
+              autoComplete="username"
+              disabled={isLoading}
+              required
+            />
+          </div>
+          <div>
+            <label htmlFor="admin-password" className="text-sm font-medium text-slate-700">
+              Password
+            </label>
+            <input
+              id="admin-password"
+              type="password"
+              name="password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              className="mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-slate-500 focus:outline-none"
+              autoComplete="current-password"
+              disabled={isLoading}
+              required
+            />
+          </div>
+          {localError && <p className="text-sm text-red-600">{localError}</p>}
+          <button
+            type="submit"
+            className="w-full rounded bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-60"
+            disabled={isLoading}
+          >
+            {isLoading ? 'Signing in…' : 'Sign in'}
+          </button>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/src/context/AdminAuthContext.tsx
+++ b/src/context/AdminAuthContext.tsx
@@ -1,0 +1,146 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react'
+
+import { ApiError, apiRequest, setAuthToken, setUnauthorizedHandler } from '@/src/lib/api'
+
+interface AdminAuthContextValue {
+  token: string | null
+  isAuthenticated: boolean
+  isReady: boolean
+  isLoading: boolean
+  error: string | null
+  login: (username: string, password: string) => Promise<void>
+  logout: () => void
+  clearError: () => void
+}
+
+const AdminAuthContext = createContext<AdminAuthContextValue | undefined>(undefined)
+
+const STORAGE_KEY = 'admin.auth.token'
+
+function readStoredToken(): string | null {
+  if (typeof window === 'undefined') {
+    return null
+  }
+  try {
+    return window.sessionStorage.getItem(STORAGE_KEY)
+  } catch {
+    return null
+  }
+}
+
+function persistToken(token: string | null): void {
+  if (typeof window === 'undefined') {
+    return
+  }
+  try {
+    if (token) {
+      window.sessionStorage.setItem(STORAGE_KEY, token)
+    } else {
+      window.sessionStorage.removeItem(STORAGE_KEY)
+    }
+  } catch {
+    // Ignore persistence failures (e.g., storage disabled)
+  }
+}
+
+export function AdminAuthProvider({ children }: { children: ReactNode }) {
+  const [token, setTokenState] = useState<string | null>(null)
+  const [isReady, setIsReady] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const applyToken = useCallback((value: string | null) => {
+    setTokenState(value)
+    setAuthToken(value)
+    persistToken(value)
+  }, [])
+
+  useEffect(() => {
+    const stored = readStoredToken()
+    if (stored) {
+      applyToken(stored)
+    }
+    setIsReady(true)
+  }, [applyToken])
+
+  useEffect(() => {
+    setUnauthorizedHandler(() => {
+      applyToken(null)
+    })
+    return () => {
+      setUnauthorizedHandler(null)
+    }
+  }, [applyToken])
+
+  const logout = useCallback(() => {
+    applyToken(null)
+  }, [applyToken])
+
+  const login = useCallback(
+    async (username: string, password: string) => {
+      setIsLoading(true)
+      setError(null)
+      try {
+        const payload = await apiRequest<{ token?: string }>(
+          '/v1/auth/login',
+          {
+            method: 'POST',
+            json: { username, password },
+            auth: false,
+          },
+        )
+        if (!payload?.token) {
+          throw new ApiError('Authentication response missing token', 500, payload)
+        }
+        applyToken(payload.token)
+      } catch (err: any) {
+        if (err instanceof ApiError) {
+          setError(err.message)
+        } else if (typeof err?.message === 'string') {
+          setError(err.message)
+        } else {
+          setError('Unable to authenticate. Please try again.')
+        }
+        applyToken(null)
+        throw err
+      } finally {
+        setIsLoading(false)
+      }
+    },
+    [applyToken],
+  )
+
+  const clearError = useCallback(() => setError(null), [])
+
+  const value = useMemo<AdminAuthContextValue>(
+    () => ({
+      token,
+      isAuthenticated: Boolean(token),
+      isReady,
+      isLoading,
+      error,
+      login,
+      logout,
+      clearError,
+    }),
+    [token, isReady, isLoading, error, login, logout, clearError],
+  )
+
+  return <AdminAuthContext.Provider value={value}>{children}</AdminAuthContext.Provider>
+}
+
+export function useAdminAuth(): AdminAuthContextValue {
+  const context = useContext(AdminAuthContext)
+  if (!context) {
+    throw new Error('useAdminAuth must be used within an AdminAuthProvider')
+  }
+  return context
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,138 @@
+import { API_BASE_URL } from './config'
+
+export class ApiError<T = unknown> extends Error {
+  public readonly status: number
+  public readonly data: T | null
+
+  constructor(message: string, status: number, data: T | null) {
+    super(message)
+    this.status = status
+    this.data = data
+  }
+}
+
+type UnauthorizedHandler = () => void
+
+let authToken: string | null = null
+let unauthorizedHandler: UnauthorizedHandler | null = null
+
+export function setAuthToken(token: string | null): void {
+  authToken = token
+}
+
+export function getAuthToken(): string | null {
+  return authToken
+}
+
+export function setUnauthorizedHandler(handler: UnauthorizedHandler | null): void {
+  unauthorizedHandler = handler
+}
+
+export interface ApiFetchOptions extends RequestInit {
+  auth?: boolean
+}
+
+function resolveUrl(path: string): string {
+  if (/^https?:/i.test(path)) {
+    return path
+  }
+  const base = API_BASE_URL
+  if (!base) {
+    return path
+  }
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`
+  return `${base}${normalizedPath}`
+}
+
+export async function apiFetch(path: string, options: ApiFetchOptions = {}): Promise<Response> {
+  const { auth = true, headers, ...rest } = options
+  const requestHeaders =
+    headers instanceof Headers ? headers : new Headers(headers ? (headers as HeadersInit) : undefined)
+  if (auth && authToken && !requestHeaders.has('Authorization')) {
+    requestHeaders.set('Authorization', `Bearer ${authToken}`)
+  }
+
+  const response = await fetch(resolveUrl(path), {
+    ...rest,
+    headers: requestHeaders,
+    credentials: 'omit',
+  })
+
+  if (response.status === 401 && auth && unauthorizedHandler) {
+    unauthorizedHandler()
+  }
+
+  return response
+}
+
+export interface ApiRequestOptions<TBody = unknown> extends ApiFetchOptions {
+  json?: TBody
+}
+
+function resolveBody(options: ApiRequestOptions): {
+  body: BodyInit | null | undefined
+  headers: Headers
+} {
+  const headers =
+    options.headers instanceof Headers
+      ? options.headers
+      : new Headers(options.headers ? (options.headers as HeadersInit) : undefined)
+
+  if (options.json !== undefined) {
+    if (!headers.has('Content-Type')) {
+      headers.set('Content-Type', 'application/json')
+    }
+    return { body: JSON.stringify(options.json), headers }
+  }
+
+  return { body: options.body, headers }
+}
+
+function extractErrorMessage(data: unknown, status: number): string {
+  if (typeof data === 'string' && data.trim().length > 0) {
+    return data
+  }
+  if (data && typeof data === 'object') {
+    const maybeError = (data as Record<string, unknown>).error
+    if (typeof maybeError === 'string' && maybeError.length > 0) {
+      return maybeError
+    }
+    const maybeMessage = (data as Record<string, unknown>).message
+    if (typeof maybeMessage === 'string' && maybeMessage.length > 0) {
+      return maybeMessage
+    }
+  }
+  return `Request failed with status ${status}`
+}
+
+export async function apiRequest<TResponse = unknown, TBody = unknown>(
+  path: string,
+  options: ApiRequestOptions<TBody> = {},
+): Promise<TResponse> {
+  const { body, headers } = resolveBody(options)
+  const response = await apiFetch(path, { ...options, headers, body })
+
+  const contentType = response.headers.get('content-type') || ''
+  let payload: unknown = null
+
+  if (contentType.includes('application/json')) {
+    try {
+      payload = await response.json()
+    } catch {
+      payload = null
+    }
+  } else {
+    try {
+      const text = await response.text()
+      payload = text.length > 0 ? text : null
+    } catch {
+      payload = null
+    }
+  }
+
+  if (!response.ok) {
+    throw new ApiError(extractErrorMessage(payload, response.status), response.status, payload)
+  }
+
+  return payload as TResponse
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,6 @@
+export const API_BASE_URL = (process.env.NEXT_PUBLIC_API_URL || '').replace(/\/$/, '')
+
+export const USE_API_READ =
+  typeof process.env.NEXT_PUBLIC_USE_API_READ === 'string'
+    ? process.env.NEXT_PUBLIC_USE_API_READ !== 'false'
+    : true


### PR DESCRIPTION
## Summary
- add an API helper and admin auth context to manage JWT tokens and handle unauthorized sessions
- update admin manager screens and property tools to use the new login form, call /v1 endpoints, and wire workflow/scheduler actions to the backend
- harden the search worker to tolerate missing index files and expose configuration for API-driven reads

## Testing
- npm run lint
- npm run typecheck *(fails: existing TypeScript issues outside the touched areas)*

------
https://chatgpt.com/codex/tasks/task_e_68ca56a1eb24832b9efe8988d75d210c