### PR TITLE
refactor: centralize page loaders in views

### DIFF
--- a/pages/[locale]/guides/[slug].tsx
+++ b/pages/[locale]/guides/[slug].tsx
@@ -1,89 +1,17 @@
-import fs from 'fs'
-import path from 'path'
-import { GetStaticPaths, GetStaticProps } from 'next'
-import { MDXRemoteSerializeResult } from 'next-mdx-remote'
-import { serialize } from 'next-mdx-remote/serialize'
-import { useRouter } from 'next/router'
 import { NextSeo, ArticleJsonLd } from 'next-seo'
-import { useTranslation } from 'next-i18next'
-import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
-import { getSeoUrls, getLanguageAlternates } from 'lib/seo'
 import BreadcrumbJsonLd from '@/components/JsonLd/BreadcrumbJsonLd'
-import { guidesCrumbs } from '@/lib/nav/crumbs'
-import GuideDetailPageContent, { ArticleData } from '@/views/guides/GuideDetailPageContent'
+import GuideDetailView, { GuideDetailViewProps } from '@/views/guides/guideDetailView'
 
-interface Props {
-  source: MDXRemoteSerializeResult
-  article: ArticleData
-}
+export { getStaticPaths, getStaticProps } from '@/views/guides/guideDetailView'
 
-export default function GuideDetail({ source, article }: Props) {
-  const router = useRouter()
-  const { t } = useTranslation('common')
-  const lang = Array.isArray(router.query.locale)
-    ? router.query.locale[0]
-    : (router.query.locale as string)
-  const { pageUrl } = getSeoUrls(lang, `/guides/${article.slug}`)
-  const crumbs = guidesCrumbs(lang, article.slug, article.title)
-
+export default function GuideDetailPage(props: GuideDetailViewProps) {
+  const { head } = props
   return (
     <>
-      <NextSeo
-        title={article.title}
-        canonical={pageUrl}
-        openGraph={{ images: [{ url: article.coverImage }] }}
-        languageAlternates={getLanguageAlternates(`/guides/${article.slug}`)}
-      />
-      <BreadcrumbJsonLd items={crumbs} />
-      <ArticleJsonLd
-        url={pageUrl}
-        title={article.title}
-        images={[article.coverImage]}
-        datePublished={article.publishedAt}
-        authorName={[t('Brand.name')]}
-        description={article.title}
-      />
-      <GuideDetailPageContent source={source} article={article} crumbs={crumbs} />
+      <NextSeo {...head.seo} />
+      <BreadcrumbJsonLd items={head.breadcrumb} />
+      <ArticleJsonLd {...head.articleJsonLd} />
+      <GuideDetailView {...props} />
     </>
   )
-}
-
-export const getStaticPaths: GetStaticPaths = async () => {
-  const dataPath = path.join(process.cwd(), 'public', 'data', 'articles.json')
-  const raw: any[] = JSON.parse(fs.readFileSync(dataPath, 'utf-8'))
-  const locales = ['en', 'th']
-  const paths: { params: { locale: string; slug: string } }[] = []
-  for (const article of raw) {
-    for (const locale of locales) {
-      if (article.locales[locale]) {
-        paths.push({ params: { locale, slug: article.slug } })
-      }
-    }
-  }
-  return { paths, fallback: false }
-}
-
-export const getStaticProps: GetStaticProps<Props> = async ({ params }) => {
-  const { locale, slug } = params as { locale: string; slug: string }
-  const dataPath = path.join(process.cwd(), 'public', 'data', 'articles.json')
-  const raw: any[] = JSON.parse(fs.readFileSync(dataPath, 'utf-8'))
-  const entry = raw.find((a) => a.slug === slug)
-  const mdxFile = path.join(process.cwd(), 'public', 'data', 'articles', entry.locales[locale]?.mdx || entry.locales.en.mdx)
-  const source = fs.readFileSync(mdxFile, 'utf-8')
-  const mdxSource = await serialize(source)
-  const article: ArticleData = {
-    slug: entry.slug,
-    category: entry.category,
-    coverImage: entry.coverImage,
-    publishedAt: entry.publishedAt,
-    provinces: entry.provinces,
-    title: entry.locales[locale]?.title || entry.locales.en.title,
-  }
-  return {
-    props: {
-      source: mdxSource,
-      article,
-      ...(await serverSideTranslations(locale || 'th', ['common'])),
-    },
-  }
 }

--- a/pages/[locale]/guides/index.tsx
+++ b/pages/[locale]/guides/index.tsx
@@ -1,62 +1,16 @@
-import fs from 'fs'
-import path from 'path'
-import { GetStaticPaths, GetStaticProps } from 'next'
-import { useRouter } from 'next/router'
 import { NextSeo } from 'next-seo'
-import { getSeoUrls, getLanguageAlternates } from 'lib/seo'
 import BreadcrumbJsonLd from '@/components/JsonLd/BreadcrumbJsonLd'
-import { guidesCrumbs } from '@/lib/nav/crumbs'
-import GuidesPageContent, { Article } from '@/views/guides/GuidesPageContent'
+import GuidesListView, { GuidesListViewProps } from '@/views/guides/guidesListView'
 
-interface Props {
-  articles: Article[]
-  categories: string[]
-}
+export { getStaticPaths, getStaticProps } from '@/views/guides/guidesListView'
 
-export default function GuidesList({ articles, categories }: Props) {
-  const router = useRouter()
-  const lang = Array.isArray(router.query.locale)
-    ? router.query.locale[0]
-    : (router.query.locale as string)
-  const { pageUrl } = getSeoUrls(lang, '/guides')
-  const crumbs = guidesCrumbs(lang)
-
+export default function GuidesListPage(props: GuidesListViewProps) {
+  const { head } = props
   return (
     <>
-      <NextSeo
-        title='Guides'
-        canonical={pageUrl}
-        languageAlternates={getLanguageAlternates('/guides')}
-      />
-      <BreadcrumbJsonLd items={crumbs} />
-      <GuidesPageContent
-        articles={articles}
-        categories={categories}
-        lang={lang}
-        crumbs={crumbs}
-      />
+      <NextSeo {...head.seo} />
+      <BreadcrumbJsonLd items={head.breadcrumb} />
+      <GuidesListView {...props} />
     </>
   )
-}
-
-export const getStaticPaths: GetStaticPaths = async () => {
-  const locales = ['en', 'th']
-  const paths = locales.map((locale) => ({ params: { locale } }))
-  return { paths, fallback: false }
-}
-
-export const getStaticProps: GetStaticProps<Props> = async ({ params }) => {
-  const locale = params?.locale as string
-  const dataPath = path.join(process.cwd(), 'public', 'data', 'articles.json')
-  const raw: any[] = JSON.parse(fs.readFileSync(dataPath, 'utf-8'))
-  const articles: Article[] = raw.map((a) => ({
-    slug: a.slug,
-    category: a.category,
-    coverImage: a.coverImage,
-    publishedAt: a.publishedAt,
-    provinces: a.provinces,
-    title: a.locales[locale]?.title || a.locales.en.title,
-  }))
-  const categories = Array.from(new Set(raw.map((a) => a.category)))
-  return { props: { articles, categories } }
 }

--- a/pages/[locale]/properties/[id].tsx
+++ b/pages/[locale]/properties/[id].tsx
@@ -1,110 +1,24 @@
-import fs from 'fs'
-import path from 'path'
-import { GetStaticPaths, GetStaticProps } from 'next'
-import { useRouter } from 'next/router'
-import { NextSeo } from 'next-seo'
 import Script from 'next/script'
-import { getSeoUrls, getLanguageAlternates } from 'lib/seo'
+import { NextSeo } from 'next-seo'
 import BreadcrumbJsonLd from '@/components/JsonLd/BreadcrumbJsonLd'
-import { pdpCrumbs } from '@/lib/nav/crumbs'
-import PropertyDetailPageContent, {
-  Property,
-  Article,
-} from '@/views/properties/PropertyDetailPageContent'
-import { asSrc } from '@/components/PropertyImage'
-import type { ImgLike } from '@/components/PropertyImage'
+import PropertyDetailView, { PropertyDetailViewProps } from '@/views/properties/propertyDetailView'
 
-interface Props {
-  property: Property
-  articles: Article[]
-}
+export { getStaticPaths, getStaticProps } from '@/views/properties/propertyDetailView'
 
-export default function PropertyDetail({ property, articles }: Props) {
-  const router = useRouter()
-  const lang = Array.isArray(router.query.locale)
-    ? router.query.locale[0]
-    : (router.query.locale as string)
-  let titleLocale: 'en' | 'th' | 'zh' = 'en'
-  if (lang === 'th' || lang === 'zh') {
-    titleLocale = lang
-  }
-  const title = property.title[titleLocale] || property.title.en
-  const provinceName =
-    property.province[lang === 'th' ? 'th' : 'en'] || property.province.en
-  const { pageUrl } = getSeoUrls(lang, `/properties/${property.id}`)
-  const crumbs = pdpCrumbs(lang, property.id, title)
-
+export default function PropertyDetailPage(props: PropertyDetailViewProps) {
+  const { head } = props
   return (
     <>
-      <NextSeo
-        title={title}
-        canonical={pageUrl}
-        languageAlternates={getLanguageAlternates(`/properties/${property.id}`)}
-      />
-      <BreadcrumbJsonLd items={crumbs} />
-      <PropertyDetailPageContent
-        property={property}
-        articles={articles}
-        lang={lang}
-        title={title}
-        provinceName={provinceName}
-        crumbs={crumbs}
-      />
+      <NextSeo {...head.seo} />
+      <BreadcrumbJsonLd items={head.breadcrumb} />
       <Script
         id='realestate-listing'
         type='application/ld+json'
         dangerouslySetInnerHTML={{
-          __html: JSON.stringify({
-            '@context': 'https://schema.org',
-            '@type': 'RealEstateListing',
-            url: pageUrl,
-            name: title,
-            description: title,
-            address: {
-              '@type': 'PostalAddress',
-              addressRegion: provinceName,
-              addressCountry: 'TH',
-            },
-            offers: {
-              '@type': 'Offer',
-              price: property.price,
-              priceCurrency: 'THB',
-            },
-            image: (property.images ?? []).map((img: ImgLike) => asSrc(img)),
-          }).replace(/</g, '\\u003c'),
+          __html: JSON.stringify(head.realEstateJson).replace(/</g, '\\u003c'),
         }}
       />
+      <PropertyDetailView {...props} />
     </>
   )
-}
-
-export const getStaticPaths: GetStaticPaths = async () => {
-  const dataPath = path.join(process.cwd(), 'public', 'data', 'properties.json')
-  const properties: Property[] = JSON.parse(fs.readFileSync(dataPath, 'utf-8'))
-  const locales = ['en', 'th', 'zh']
-  const paths = []
-  for (const p of properties) {
-    for (const locale of locales) {
-      paths.push({ params: { locale, id: p.id.toString() } })
-    }
-  }
-  return { paths, fallback: false }
-}
-
-export const getStaticProps: GetStaticProps<Props> = async ({ params }) => {
-  const { id, locale } = params as { id: string; locale: string }
-  const dataPath = path.join(process.cwd(), 'public', 'data', 'properties.json')
-  const properties: Property[] = JSON.parse(fs.readFileSync(dataPath, 'utf-8'))
-  const property = properties.find((p) => p.id === Number(id))!
-  const articlesRaw: any[] = JSON.parse(
-    fs.readFileSync(path.join(process.cwd(), 'public', 'data', 'articles.json'), 'utf-8')
-  )
-  const articles: Article[] = articlesRaw.map((a) => ({
-    slug: a.slug,
-    category: a.category,
-    provinces: a.provinces,
-    coverImage: a.coverImage,
-    title: a.locales[locale]?.title || a.locales.en.title,
-  }))
-  return { props: { property, articles } }
 }

--- a/pages/[locale]/search/index.tsx
+++ b/pages/[locale]/search/index.tsx
@@ -1,22 +1,14 @@
 import { NextSeo } from 'next-seo'
-import { useRouter } from 'next/router'
-import { getSeoUrls, getLanguageAlternates } from 'lib/seo'
-import SearchPageContent from '@/views/search/SearchPageContent'
+import SearchView, { SearchViewProps } from '@/views/search/searchView'
 
-export default function SearchPage() {
-  const { locale, defaultLocale } = useRouter()
-  const lang = locale || defaultLocale || 'th'
-  const { pageUrl } = getSeoUrls(lang, '/search')
+export { getStaticPaths, getStaticProps } from '@/views/search/searchView'
 
+export default function SearchPage(props: SearchViewProps) {
+  const { head } = props
   return (
     <>
-      <NextSeo
-        title='Search'
-        canonical={pageUrl}
-        noindex
-        languageAlternates={getLanguageAlternates('/search')}
-      />
-      <SearchPageContent />
+      <NextSeo {...head.seo} />
+      <SearchView {...props} />
     </>
   )
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,128 +1,37 @@
-import { GetStaticProps } from 'next'
-import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
-import { useTranslation } from 'next-i18next'
+import Script from 'next/script'
 import {
   NextSeo,
   LocalBusinessJsonLd,
   WebPageJsonLd,
   BreadcrumbJsonLd,
 } from 'next-seo'
-import { useRouter } from 'next/router'
-import Script from 'next/script'
-import HomePageContent from '../src/views/home/HomePageContent'
-import { getOpenGraph, getLanguageAlternates, getSeoUrls } from '../lib/seo'
+import HomeView, { HomeViewProps } from '@/views/home/homeView'
 
-export default function Home() {
-  const { t } = useTranslation('common')
-  const { locale, defaultLocale } = useRouter()
-  const lang = locale || defaultLocale || 'th'
-  const keywords = t('seo_keywords', { returnObjects: true }) as string[]
-  const { baseUrl, siteUrl, pageUrl } = getSeoUrls(lang)
-  const brandName = t('Brand.name')
-  const brandTagline = t('Brand.tagline')
+export { getStaticProps } from '@/views/home/homeView'
+
+export default function HomePage(props: HomeViewProps) {
+  const { head } = props
   return (
     <>
-      <NextSeo
-        title={t('seo_title')}
-        description={t('seo_description')}
-        canonical={pageUrl}
-        openGraph={{
-          ...getOpenGraph(
-            lang,
-            pageUrl,
-            t('seo_title'),
-            t('seo_description')
-          ),
-          images: [
-            {
-              url: `${baseUrl}/og-home.png`,
-              width: 1845,
-              height: 871,
-              alt: `${t('seo_title')} Open Graph Image`,
-            },
-          ],
-        }}
-        additionalMetaTags={[{
-          name: 'keywords',
-          content: keywords.join(', '),
-        }]}
-        languageAlternates={getLanguageAlternates()}
-      />
-      <WebPageJsonLd
-        id={pageUrl}
-        url={pageUrl}
-        title={t('seo_title')}
-        description={t('seo_description')}
-      />
-      <BreadcrumbJsonLd
-        itemListElements={[{
-          position: 1,
-          name: t('seo_title'),
-          item: pageUrl,
-        }]}
-      />
-      <LocalBusinessJsonLd
-        type='RealEstateAgent'
-        id={siteUrl}
-        name={brandName}
-        description={brandTagline}
-        url={siteUrl}
-        telephone='+66-2-123-4567'
-        address={{
-          streetAddress: '123 Example Road',
-          addressLocality: 'Bangkok',
-          addressRegion: 'Bangkok',
-          postalCode: '10110',
-          addressCountry: 'TH',
-        }}
-        geo={{ latitude: '13.7563', longitude: '100.5018' }}
-        openingHours={[{
-          opens: '09:00',
-          closes: '17:00',
-          dayOfWeek: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'],
-        }]}
-      />
+      <NextSeo {...head.seo} />
+      <WebPageJsonLd {...head.webPage} />
+      <BreadcrumbJsonLd itemListElements={head.breadcrumb} />
+      <LocalBusinessJsonLd {...head.localBusiness} />
       <Script
         id='website'
         type='application/ld+json'
         dangerouslySetInnerHTML={{
-          __html: JSON.stringify({
-            '@context': 'https://schema.org',
-            '@type': 'WebSite',
-            url: siteUrl,
-            potentialAction: {
-              '@type': 'SearchAction',
-              target: `${siteUrl}/search?query={search_term_string}`,
-              'query-input': 'required name=search_term_string',
-            },
-          }).replace(/</g, '\\u003c'),
+          __html: JSON.stringify(head.websiteJson).replace(/</g, '\\u003c'),
         }}
       />
-      {/* eslint-disable-next-line react/no-danger */}
       <Script
         id='speakable'
         type='application/ld+json'
         dangerouslySetInnerHTML={{
-          __html: JSON.stringify({
-            '@context': 'https://schema.org',
-            '@type': 'WebPage',
-            name: t('seo_title'),
-            description: t('seo_description'),
-            url: pageUrl,
-            speakable: {
-              '@type': 'SpeakableSpecification',
-              cssSelector: ['h1', 'p'],
-            },
-          }).replace(/</g, '\\u003c'),
+          __html: JSON.stringify(head.speakableJson).replace(/</g, '\\u003c'),
         }}
       />
-      <HomePageContent keywords={keywords} />
+      <HomeView {...props} />
     </>
   )
 }
-
-export const getStaticProps: GetStaticProps = async ({ locale }) => ({
-  props: {
-    ...(await serverSideTranslations(locale ?? 'th', ['common'])),
-  },
-})

--- a/pages/properties.tsx
+++ b/pages/properties.tsx
@@ -1,91 +1,16 @@
-import { useEffect, useState } from 'react'
-import { useRouter } from 'next/router'
 import { NextSeo } from 'next-seo'
-import Script from 'next/script'
-import PropertyFilters, { Filters } from '@/components/PropertyFilters'
-import PropertyCard from '@/components/PropertyCard'
-import { filterParamsSchema } from '@/lib/validation/search'
-import { getLanguageAlternates, getSeoUrls } from 'lib/seo'
-import Breadcrumbs from '@/components/Breadcrumbs'
 import BreadcrumbJsonLd from '@/components/JsonLd/BreadcrumbJsonLd'
-import { listingCrumbs } from '@/lib/nav/crumbs'
+import PropertySearchView, { PropertySearchViewProps } from '@/views/properties/propertySearchView'
 
-interface SearchResponse {
-  total: number;
-  results: any[];
-}
+export { getServerSideProps } from '@/views/properties/propertySearchView'
 
-export default function PropertySearchPage() {
-  const router = useRouter()
-  const locale = router.locale || router.defaultLocale || 'en'
-  const [filters, setFilters] = useState<Filters>({})
-  const [results, setResults] = useState<any[]>([])
-  const { pageUrl } = getSeoUrls(locale, '/properties')
-  const crumbs = listingCrumbs(locale)
-
-  const runSearch = (f: Filters) => {
-    const worker = new Worker(new URL('../src/workers/search.worker.ts', import.meta.url))
-    worker.onmessage = (e: MessageEvent<SearchResponse>) => {
-      setResults(e.data.results)
-      worker.terminate()
-    }
-    worker.postMessage({ locale, query: '', ...f })
-  }
-
-  useEffect(() => {
-    const parsed = filterParamsSchema.safeParse(router.query);
-    if (parsed.success) {
-      const q = parsed.data as Filters;
-      setFilters(q);
-      runSearch(q);
-    } else {
-      runSearch({});
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  const handleChange = (f: Filters) => {
-    const safe = filterParamsSchema.parse(f) as Filters
-    setFilters(safe)
-    const query = Object.fromEntries(
-      Object.entries(safe).filter(([, v]) => v !== undefined && v !== '' && !(Array.isArray(v) && v.length === 0))
-    )
-    router.replace({ pathname: router.pathname, query }, undefined, { shallow: true })
-    runSearch(safe)
-  }
-
+export default function PropertySearchPage(props: PropertySearchViewProps) {
+  const { head } = props
   return (
-    <div className='p-4 space-y-4'>
-      <NextSeo
-        title='Property Listings'
-        canonical={pageUrl}
-        languageAlternates={getLanguageAlternates('/properties')}
-      />
-      <BreadcrumbJsonLd items={crumbs} />
-      <Breadcrumbs items={crumbs} />
-      <PropertyFilters filters={filters} onChange={handleChange} />
-      <div className='grid grid-cols-1 md:grid-cols-2 gap-4'>
-        {results.map((p) => (
-          <PropertyCard key={p.id} property={p} locale={locale} />
-        ))}
-      </div>
-      {results.length > 0 && (
-        <Script
-          id='property-itemlist'
-          type='application/ld+json'
-          dangerouslySetInnerHTML={{
-            __html: JSON.stringify({
-              '@context': 'https://schema.org',
-              '@type': 'ItemList',
-              itemListElement: results.map((p, i) => ({
-                '@type': 'ListItem',
-                position: i + 1,
-                url: `/${locale}/properties/${p.id}`,
-              })),
-            }).replace(/</g, '\\u003c'),
-          }}
-        />
-      )}
-    </div>
+    <>
+      <NextSeo {...head.seo} />
+      <BreadcrumbJsonLd items={head.breadcrumb} />
+      <PropertySearchView {...props} />
+    </>
   )
 }

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,0 +1,1 @@
+export * from '../../lib/seo'

--- a/src/views/guides/guideDetailView.tsx
+++ b/src/views/guides/guideDetailView.tsx
@@ -1,0 +1,109 @@
+import fs from 'fs'
+import path from 'path'
+import { GetStaticPaths, GetStaticProps } from 'next'
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import type { NextSeoProps } from 'next-seo'
+import type { ArticleJsonLdProps } from 'next-seo'
+import type { MDXRemoteSerializeResult } from 'next-mdx-remote'
+import { serialize } from 'next-mdx-remote/serialize'
+import GuideDetailPageContent, { ArticleData } from './GuideDetailPageContent'
+import { getLanguageAlternates, getSeoUrls } from '@/lib/seo'
+import { guidesCrumbs, Crumb } from '@/lib/nav/crumbs'
+import { loadCommonTranslation } from '@/views/shared/loadCommonTranslation'
+
+export interface GuideDetailHeadProps {
+  seo: NextSeoProps
+  breadcrumb: Crumb[]
+  articleJsonLd: ArticleJsonLdProps
+}
+
+export interface GuideDetailViewProps extends Record<string, unknown> {
+  source: MDXRemoteSerializeResult
+  article: ArticleData
+  lang: string
+  crumbs: Crumb[]
+  head: GuideDetailHeadProps
+}
+
+export default function GuideDetailView({ source, article, crumbs }: GuideDetailViewProps) {
+  return <GuideDetailPageContent source={source} article={article} crumbs={crumbs} />
+}
+
+export const getGuideDetailStaticPaths: GetStaticPaths = async () => {
+  const dataPath = path.join(process.cwd(), 'public', 'data', 'articles.json')
+  const raw: any[] = JSON.parse(fs.readFileSync(dataPath, 'utf-8'))
+  const locales = ['en', 'th']
+  const paths: { params: { locale: string; slug: string } }[] = []
+  for (const article of raw) {
+    for (const locale of locales) {
+      if (article.locales[locale]) {
+        paths.push({ params: { locale, slug: article.slug } })
+      }
+    }
+  }
+  return { paths, fallback: false }
+}
+
+export const getGuideDetailStaticProps: GetStaticProps<GuideDetailViewProps> = async ({
+  params,
+}) => {
+  const { locale: lang = 'th', slug } = params as { locale: string; slug: string }
+  const dataPath = path.join(process.cwd(), 'public', 'data', 'articles.json')
+  const raw: any[] = JSON.parse(fs.readFileSync(dataPath, 'utf-8'))
+  const entry = raw.find((a) => a.slug === slug)
+  if (!entry) {
+    return { notFound: true }
+  }
+  const mdxFile = path.join(
+    process.cwd(),
+    'public',
+    'data',
+    'articles',
+    entry.locales[lang]?.mdx || entry.locales.en.mdx,
+  )
+  const sourceContent = fs.readFileSync(mdxFile, 'utf-8')
+  const mdxSource = await serialize(sourceContent)
+  const article: ArticleData = {
+    slug: entry.slug,
+    category: entry.category,
+    coverImage: entry.coverImage,
+    publishedAt: entry.publishedAt,
+    provinces: entry.provinces,
+    title: entry.locales[lang]?.title || entry.locales.en.title,
+  }
+  const translations = await serverSideTranslations(lang, ['common'])
+  const common = loadCommonTranslation(lang)
+  const brandName = common.Brand?.name || ''
+  const { pageUrl } = getSeoUrls(lang, `/guides/${article.slug}`)
+  const crumbs = guidesCrumbs(lang, article.slug, article.title)
+
+  return {
+    props: {
+      source: mdxSource,
+      article,
+      lang,
+      crumbs,
+      head: {
+        seo: {
+          title: article.title,
+          canonical: pageUrl,
+          openGraph: { images: [{ url: article.coverImage }] },
+          languageAlternates: getLanguageAlternates(`/guides/${article.slug}`),
+        },
+        breadcrumb: crumbs,
+        articleJsonLd: {
+          url: pageUrl,
+          title: article.title,
+          images: [article.coverImage],
+          datePublished: article.publishedAt,
+          authorName: [brandName],
+          description: article.title,
+        },
+      },
+      ...translations,
+    },
+  }
+}
+
+export const getStaticPaths = getGuideDetailStaticPaths
+export const getStaticProps = getGuideDetailStaticProps

--- a/src/views/guides/guidesListView.tsx
+++ b/src/views/guides/guidesListView.tsx
@@ -1,0 +1,81 @@
+import fs from 'fs'
+import path from 'path'
+import { GetStaticPaths, GetStaticProps } from 'next'
+import type { NextSeoProps } from 'next-seo'
+import GuidesPageContent, { Article } from './GuidesPageContent'
+import { getLanguageAlternates, getSeoUrls } from '@/lib/seo'
+import { guidesCrumbs, Crumb } from '@/lib/nav/crumbs'
+
+export interface GuidesListHeadProps {
+  seo: NextSeoProps
+  breadcrumb: Crumb[]
+}
+
+export interface GuidesListViewProps {
+  lang: string
+  articles: Article[]
+  categories: string[]
+  crumbs: Crumb[]
+  head: GuidesListHeadProps
+}
+
+export default function GuidesListView({
+  articles,
+  categories,
+  lang,
+  crumbs,
+}: GuidesListViewProps) {
+  return (
+    <GuidesPageContent
+      articles={articles}
+      categories={categories}
+      lang={lang}
+      crumbs={crumbs}
+    />
+  )
+}
+
+export const getGuidesListStaticPaths: GetStaticPaths = async () => {
+  const locales = ['en', 'th']
+  const paths = locales.map((locale) => ({ params: { locale } }))
+  return { paths, fallback: false }
+}
+
+export const getGuidesListStaticProps: GetStaticProps<GuidesListViewProps> = async ({
+  params,
+}) => {
+  const lang = (params?.locale as string) || 'th'
+  const dataPath = path.join(process.cwd(), 'public', 'data', 'articles.json')
+  const raw: any[] = JSON.parse(fs.readFileSync(dataPath, 'utf-8'))
+  const articles: Article[] = raw.map((a) => ({
+    slug: a.slug,
+    category: a.category,
+    coverImage: a.coverImage,
+    publishedAt: a.publishedAt,
+    provinces: a.provinces,
+    title: a.locales[lang]?.title || a.locales.en.title,
+  }))
+  const categories = Array.from(new Set(raw.map((a) => a.category)))
+  const crumbs = guidesCrumbs(lang)
+  const { pageUrl } = getSeoUrls(lang, '/guides')
+
+  return {
+    props: {
+      lang,
+      articles,
+      categories,
+      crumbs,
+      head: {
+        seo: {
+          title: 'Guides',
+          canonical: pageUrl,
+          languageAlternates: getLanguageAlternates('/guides'),
+        },
+        breadcrumb: crumbs,
+      },
+    },
+  }
+}
+
+export const getStaticPaths = getGuidesListStaticPaths
+export const getStaticProps = getGuidesListStaticProps

--- a/src/views/home/homeView.tsx
+++ b/src/views/home/homeView.tsx
@@ -1,0 +1,139 @@
+import { GetStaticProps } from 'next'
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import type {
+  NextSeoProps,
+  LocalBusinessJsonLdProps,
+  WebPageJsonLdProps,
+} from 'next-seo'
+import HomePageContent from './HomePageContent'
+import { getOpenGraph, getLanguageAlternates, getSeoUrls } from '@/lib/seo'
+import { loadCommonTranslation } from '@/views/shared/loadCommonTranslation'
+
+export interface HomeHeadProps {
+  seo: NextSeoProps
+  webPage: WebPageJsonLdProps
+  breadcrumb: { position: number; name: string; item: string }[]
+  localBusiness: LocalBusinessJsonLdProps
+  websiteJson: Record<string, unknown>
+  speakableJson: Record<string, unknown>
+}
+
+export interface HomeViewProps extends Record<string, unknown> {
+  lang: string
+  keywords: string[]
+  head: HomeHeadProps
+}
+
+export default function HomeView({ keywords }: HomeViewProps) {
+  return <HomePageContent keywords={keywords} />
+}
+
+export const getHomeStaticProps: GetStaticProps<HomeViewProps> = async ({
+  locale,
+  defaultLocale,
+}) => {
+  const lang = locale || defaultLocale || 'th'
+  const translations = await serverSideTranslations(lang, ['common'])
+  const common = loadCommonTranslation(lang)
+  const keywords = Array.isArray(common.seo_keywords) ? common.seo_keywords : []
+  const title = typeof common.seo_title === 'string' ? common.seo_title : ''
+  const description =
+    typeof common.seo_description === 'string' ? common.seo_description : ''
+  const brandName = common.Brand?.name || ''
+  const brandTagline = common.Brand?.tagline || ''
+  const { baseUrl, siteUrl, pageUrl } = getSeoUrls(lang)
+
+  const head: HomeHeadProps = {
+    seo: {
+      title,
+      description,
+      canonical: pageUrl,
+      openGraph: {
+        ...getOpenGraph(lang, pageUrl, title, description),
+        images: [
+          {
+            url: `${baseUrl}/og-home.png`,
+            width: 1845,
+            height: 871,
+            alt: `${title} Open Graph Image`,
+          },
+        ],
+      },
+      additionalMetaTags: [
+        {
+          name: 'keywords',
+          content: keywords.join(', '),
+        },
+      ],
+      languageAlternates: getLanguageAlternates(),
+    },
+    webPage: {
+      id: pageUrl,
+      url: pageUrl,
+      title,
+      description,
+    },
+    breadcrumb: [
+      {
+        position: 1,
+        name: title,
+        item: pageUrl,
+      },
+    ],
+    localBusiness: {
+      type: 'RealEstateAgent',
+      id: siteUrl,
+      name: brandName,
+      description: brandTagline,
+      url: siteUrl,
+      telephone: '+66-2-123-4567',
+      address: {
+        streetAddress: '123 Example Road',
+        addressLocality: 'Bangkok',
+        addressRegion: 'Bangkok',
+        postalCode: '10110',
+        addressCountry: 'TH',
+      },
+      geo: { latitude: '13.7563', longitude: '100.5018' },
+      openingHours: [
+        {
+          opens: '09:00',
+          closes: '17:00',
+          dayOfWeek: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'],
+        },
+      ],
+    },
+    websiteJson: {
+      '@context': 'https://schema.org',
+      '@type': 'WebSite',
+      url: siteUrl,
+      potentialAction: {
+        '@type': 'SearchAction',
+        target: `${siteUrl}/search?query={search_term_string}`,
+        'query-input': 'required name=search_term_string',
+      },
+    },
+    speakableJson: {
+      '@context': 'https://schema.org',
+      '@type': 'WebPage',
+      name: title,
+      description,
+      url: pageUrl,
+      speakable: {
+        '@type': 'SpeakableSpecification',
+        cssSelector: ['h1', 'p'],
+      },
+    },
+  }
+
+  return {
+    props: {
+      lang,
+      keywords,
+      head,
+      ...translations,
+    },
+  }
+}
+
+export const getStaticProps = getHomeStaticProps

--- a/src/views/properties/propertyDetailView.tsx
+++ b/src/views/properties/propertyDetailView.tsx
@@ -1,0 +1,126 @@
+import fs from 'fs'
+import path from 'path'
+import { GetStaticPaths, GetStaticProps } from 'next'
+import type { NextSeoProps } from 'next-seo'
+import PropertyDetailPageContent, {
+  Property,
+  Article,
+} from './PropertyDetailPageContent'
+import { pdpCrumbs, Crumb } from '@/lib/nav/crumbs'
+import { getLanguageAlternates, getSeoUrls } from '@/lib/seo'
+import { asSrc, ImgLike } from '@/components/PropertyImage'
+
+export interface PropertyDetailHeadProps {
+  seo: NextSeoProps
+  breadcrumb: Crumb[]
+  realEstateJson: Record<string, unknown>
+}
+
+export interface PropertyDetailViewProps {
+  property: Property
+  articles: Article[]
+  lang: string
+  title: string
+  provinceName: string
+  crumbs: Crumb[]
+  head: PropertyDetailHeadProps
+}
+
+export default function PropertyDetailView(props: PropertyDetailViewProps) {
+  const { property, articles, lang, title, provinceName, crumbs } = props
+  return (
+    <PropertyDetailPageContent
+      property={property}
+      articles={articles}
+      lang={lang}
+      title={title}
+      provinceName={provinceName}
+      crumbs={crumbs}
+    />
+  )
+}
+
+export const getPropertyDetailStaticPaths: GetStaticPaths = async () => {
+  const dataPath = path.join(process.cwd(), 'public', 'data', 'properties.json')
+  const properties: Property[] = JSON.parse(fs.readFileSync(dataPath, 'utf-8'))
+  const locales = ['en', 'th', 'zh']
+  const paths = [] as { params: { locale: string; id: string } }[]
+  for (const p of properties) {
+    for (const locale of locales) {
+      paths.push({ params: { locale, id: p.id.toString() } })
+    }
+  }
+  return { paths, fallback: false }
+}
+
+export const getPropertyDetailStaticProps: GetStaticProps<PropertyDetailViewProps> = async ({
+  params,
+}) => {
+  const { id, locale: lang = 'th' } = params as { id: string; locale: string }
+  const dataPath = path.join(process.cwd(), 'public', 'data', 'properties.json')
+  const properties: Property[] = JSON.parse(fs.readFileSync(dataPath, 'utf-8'))
+  const property = properties.find((p) => p.id === Number(id))
+  if (!property) {
+    return { notFound: true }
+  }
+  const articlesRaw: any[] = JSON.parse(
+    fs.readFileSync(path.join(process.cwd(), 'public', 'data', 'articles.json'), 'utf-8'),
+  )
+  const articles: Article[] = articlesRaw.map((a) => ({
+    slug: a.slug,
+    category: a.category,
+    provinces: a.provinces,
+    coverImage: a.coverImage,
+    title: a.locales[lang]?.title || a.locales.en.title,
+  }))
+  let titleLocale: 'en' | 'th' | 'zh' = 'en'
+  if (lang === 'th' || lang === 'zh') {
+    titleLocale = lang
+  }
+  const title = property.title[titleLocale] || property.title.en
+  const provinceName = property.province[lang === 'th' ? 'th' : 'en'] || property.province.en
+  const { pageUrl } = getSeoUrls(lang, `/properties/${property.id}`)
+  const crumbs = pdpCrumbs(lang, property.id, title)
+
+  const head: PropertyDetailHeadProps = {
+    seo: {
+      title,
+      canonical: pageUrl,
+      languageAlternates: getLanguageAlternates(`/properties/${property.id}`),
+    },
+    breadcrumb: crumbs,
+    realEstateJson: {
+      '@context': 'https://schema.org',
+      '@type': 'RealEstateListing',
+      url: pageUrl,
+      name: title,
+      description: title,
+      address: {
+        '@type': 'PostalAddress',
+        addressRegion: provinceName,
+        addressCountry: 'TH',
+      },
+      offers: {
+        '@type': 'Offer',
+        price: property.price,
+        priceCurrency: 'THB',
+      },
+      image: (property.images ?? []).map((img: ImgLike) => asSrc(img)),
+    },
+  }
+
+  return {
+    props: {
+      property,
+      articles,
+      lang,
+      title,
+      provinceName,
+      crumbs,
+      head,
+    },
+  }
+}
+
+export const getStaticPaths = getPropertyDetailStaticPaths
+export const getStaticProps = getPropertyDetailStaticProps

--- a/src/views/properties/propertySearchView.tsx
+++ b/src/views/properties/propertySearchView.tsx
@@ -1,0 +1,135 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useRouter } from 'next/router'
+import Script from 'next/script'
+import { GetServerSideProps } from 'next'
+import type { NextSeoProps } from 'next-seo'
+import PropertyFilters, { Filters } from '@/components/PropertyFilters'
+import PropertyCard from '@/components/PropertyCard'
+import { filterParamsSchema } from '@/lib/validation/search'
+import { listingCrumbs, Crumb } from '@/lib/nav/crumbs'
+import Breadcrumbs from '@/components/Breadcrumbs'
+import { getLanguageAlternates, getSeoUrls } from '@/lib/seo'
+
+interface SearchResponse {
+  total: number
+  results: any[]
+}
+
+export interface PropertySearchHeadProps {
+  seo: NextSeoProps
+  breadcrumb: Crumb[]
+}
+
+export interface PropertySearchViewProps {
+  lang: string
+  initialFilters: Filters
+  crumbs: Crumb[]
+  head: PropertySearchHeadProps
+}
+
+export default function PropertySearchView({
+  lang,
+  initialFilters,
+  crumbs,
+}: PropertySearchViewProps) {
+  const router = useRouter()
+  const [filters, setFilters] = useState<Filters>(initialFilters)
+  const [results, setResults] = useState<any[]>([])
+
+  useEffect(() => {
+    setFilters(initialFilters)
+  }, [initialFilters])
+
+  const runSearch = useCallback(
+    (f: Filters) => {
+      if (typeof window === 'undefined') return
+      const worker = new Worker(new URL('../../workers/search.worker.ts', import.meta.url))
+      worker.onmessage = (e: MessageEvent<SearchResponse>) => {
+        setResults(e.data.results)
+        worker.terminate()
+      }
+      worker.postMessage({ locale: lang, query: '', ...f })
+    },
+    [lang],
+  )
+
+  useEffect(() => {
+    runSearch(initialFilters)
+  }, [initialFilters, runSearch])
+
+  const handleChange = useCallback(
+    (f: Filters) => {
+      const safe = filterParamsSchema.parse(f) as Filters
+      setFilters(safe)
+      const query = Object.fromEntries(
+        Object.entries(safe).filter(([, v]) =>
+          Array.isArray(v) ? v.length > 0 : v !== undefined && v !== ''
+        ),
+      )
+      router.replace({ pathname: router.pathname, query }, undefined, { shallow: true })
+      runSearch(safe)
+    },
+    [router, runSearch],
+  )
+
+  const itemListJson = useMemo(() => {
+    if (results.length === 0) return null
+    return {
+      '@context': 'https://schema.org',
+      '@type': 'ItemList',
+      itemListElement: results.map((p, i) => ({
+        '@type': 'ListItem',
+        position: i + 1,
+        url: `/${lang}/properties/${p.id}`,
+      })),
+    }
+  }, [results, lang])
+
+  return (
+    <div className='p-4 space-y-4'>
+      <Breadcrumbs items={crumbs} />
+      <PropertyFilters filters={filters} onChange={handleChange} />
+      <div className='grid grid-cols-1 gap-4 md:grid-cols-2'>
+        {results.map((p) => (
+          <PropertyCard key={p.id} property={p} locale={lang} />
+        ))}
+      </div>
+      {itemListJson && (
+        <Script
+          id='property-itemlist'
+          type='application/ld+json'
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(itemListJson).replace(/</g, '\\u003c'),
+          }}
+        />
+      )}
+    </div>
+  )
+}
+
+export const getPropertySearchServerSideProps: GetServerSideProps<
+  PropertySearchViewProps
+> = async ({ locale, defaultLocale, query }) => {
+  const lang = locale || defaultLocale || 'th'
+  const parsed = filterParamsSchema.safeParse(query)
+  const initialFilters = (parsed.success ? parsed.data : {}) as Filters
+  const crumbs = listingCrumbs(lang)
+  const { pageUrl } = getSeoUrls(lang, '/properties')
+  return {
+    props: {
+      lang,
+      initialFilters,
+      crumbs,
+      head: {
+        seo: {
+          title: 'Property Listings',
+          canonical: pageUrl,
+          languageAlternates: getLanguageAlternates('/properties'),
+        },
+        breadcrumb: crumbs,
+      },
+    },
+  }
+}
+
+export const getServerSideProps = getPropertySearchServerSideProps

--- a/src/views/search/searchView.tsx
+++ b/src/views/search/searchView.tsx
@@ -1,0 +1,46 @@
+import { GetStaticPaths, GetStaticProps } from 'next'
+import type { NextSeoProps } from 'next-seo'
+import SearchPageContent from './SearchPageContent'
+import { getLanguageAlternates, getSeoUrls } from '@/lib/seo'
+
+export interface SearchHeadProps {
+  seo: NextSeoProps
+}
+
+export interface SearchViewProps {
+  lang: string
+  head: SearchHeadProps
+}
+
+export default function SearchView(_: SearchViewProps) {
+  return <SearchPageContent />
+}
+
+export const getSearchStaticPaths: GetStaticPaths = async () => {
+  const locales = ['en', 'th', 'zh']
+  const paths = locales.map((locale) => ({ params: { locale } }))
+  return { paths, fallback: false }
+}
+
+export const getSearchStaticProps: GetStaticProps<SearchViewProps> = async ({
+  params,
+}) => {
+  const lang = (params?.locale as string) || 'th'
+  const { pageUrl } = getSeoUrls(lang, '/search')
+  return {
+    props: {
+      lang,
+      head: {
+        seo: {
+          title: 'Search',
+          canonical: pageUrl,
+          noindex: true,
+          languageAlternates: getLanguageAlternates('/search'),
+        },
+      },
+    },
+  }
+}
+
+export const getStaticPaths = getSearchStaticPaths
+export const getStaticProps = getSearchStaticProps

--- a/src/views/shared/loadCommonTranslation.ts
+++ b/src/views/shared/loadCommonTranslation.ts
@@ -1,0 +1,28 @@
+import fs from 'fs'
+import path from 'path'
+
+export interface CommonTranslation {
+  seo_title?: string
+  seo_description?: string
+  seo_keywords?: string[]
+  welcome?: string
+  Brand?: {
+    name?: string
+    tagline?: string
+  }
+  [key: string]: unknown
+}
+
+const FALLBACK_ORDER = ['th', 'en']
+
+export function loadCommonTranslation(locale?: string): CommonTranslation {
+  const candidates = [locale, ...FALLBACK_ORDER].filter(Boolean) as string[]
+  for (const lang of candidates) {
+    const filePath = path.join(process.cwd(), 'locales', lang, 'common.json')
+    if (fs.existsSync(filePath)) {
+      const raw = fs.readFileSync(filePath, 'utf-8')
+      return JSON.parse(raw) as CommonTranslation
+    }
+  }
+  throw new Error('Unable to load common translation file')
+}


### PR DESCRIPTION
## Summary
- move home page SEO preparation and translations into src/views/home/homeView while exposing computed head props
- add guide listing/detail view modules that consolidate static data loading, breadcrumb generation, and JSON-LD metadata
- introduce property listing/detail and search view modules with server-side loaders and updated pages that forward head props

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc1e9ae6a0832ba57cfa3c3378a8dd