### PR TITLE
Add header search panel and autocomplete coverage

### DIFF
--- a/src/components/search/SearchPanel.tsx
+++ b/src/components/search/SearchPanel.tsx
@@ -1,0 +1,286 @@
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type FormEvent,
+  type KeyboardEvent,
+} from 'react'
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion'
+
+export type SearchLocale = 'en' | 'th' | 'zh'
+
+export interface SearchPanelProps {
+  open: boolean
+  locale?: string
+  onClose?: () => void
+  onSubmit?: (query: string, locale: SearchLocale) => void
+  id?: string
+  className?: string
+}
+
+interface SuggestionItem {
+  title: string
+  image: string
+}
+
+const PLACEHOLDER_IMAGE = '/images/placeholder.jpg'
+
+function classNames(...tokens: Array<string | false | null | undefined>) {
+  return tokens.filter(Boolean).join(' ')
+}
+
+export function normalizeSearchLocale(input?: string): SearchLocale {
+  const value = input?.toLowerCase()
+  if (value === 'th') return 'th'
+  if (value === 'zh' || value === 'zh-cn' || value === 'zh-hans') return 'zh'
+  return 'en'
+}
+
+export default function SearchPanel({
+  open,
+  locale,
+  onClose,
+  onSubmit,
+  id,
+  className,
+}: SearchPanelProps) {
+  const inputId = useId()
+  const listboxId = `${inputId}-listbox`
+  const panelRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [query, setQuery] = useState('')
+  const [suggestions, setSuggestions] = useState<SuggestionItem[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [highlightedIndex, setHighlightedIndex] = useState(-1)
+  const shouldReduceMotion = useReducedMotion()
+  const activeLocale = useMemo(() => normalizeSearchLocale(locale), [locale])
+  const fetchSequence = useRef(0)
+
+  useEffect(() => {
+    if (!open) {
+      setQuery('')
+      setSuggestions([])
+      setHighlightedIndex(-1)
+      setError(null)
+      setLoading(false)
+      return
+    }
+    const timer = window.setTimeout(() => {
+      inputRef.current?.focus()
+    }, 50)
+    return () => window.clearTimeout(timer)
+  }, [open])
+
+  useEffect(() => {
+    if (!open) return
+    const trimmed = query.trim()
+    if (!trimmed) {
+      setSuggestions([])
+      setHighlightedIndex(-1)
+      setError(null)
+      setLoading(false)
+      return
+    }
+    const currentRequest = ++fetchSequence.current
+    const controller = new AbortController()
+    setLoading(true)
+    setError(null)
+    const timeout = window.setTimeout(() => {
+      fetch(`/api/suggest?locale=${activeLocale}&q=${encodeURIComponent(trimmed)}`, {
+        signal: controller.signal,
+      })
+        .then((response) => {
+          if (!response.ok) throw new Error('Failed to fetch suggestions')
+          return response.json() as Promise<{ suggestions?: string[] }>
+        })
+        .then((data) => {
+          if (fetchSequence.current !== currentRequest) return
+          const rows = (data.suggestions ?? []).map((title) => ({
+            title,
+            image: PLACEHOLDER_IMAGE,
+          }))
+          setSuggestions(rows)
+          setHighlightedIndex(rows.length > 0 ? 0 : -1)
+        })
+        .catch((err) => {
+          if (err?.name === 'AbortError') return
+          if (fetchSequence.current !== currentRequest) return
+          setError('Unable to load suggestions')
+          setSuggestions([])
+          setHighlightedIndex(-1)
+        })
+        .finally(() => {
+          if (fetchSequence.current === currentRequest) {
+            setLoading(false)
+          }
+        })
+    }, 200)
+
+    return () => {
+      window.clearTimeout(timeout)
+      controller.abort()
+    }
+  }, [query, activeLocale, open])
+
+  useEffect(() => {
+    if (!open) return
+    const handlePointer = (event: MouseEvent | TouchEvent) => {
+      if (!panelRef.current) return
+      const target = event.target as Node | null
+      if (target && panelRef.current.contains(target)) return
+      onClose?.()
+    }
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        onClose?.()
+      }
+    }
+    document.addEventListener('mousedown', handlePointer)
+    document.addEventListener('touchstart', handlePointer)
+    document.addEventListener('keydown', handleKey)
+    return () => {
+      document.removeEventListener('mousedown', handlePointer)
+      document.removeEventListener('touchstart', handlePointer)
+      document.removeEventListener('keydown', handleKey)
+    }
+  }, [open, onClose])
+
+  const submitQuery = useCallback(
+    (value: string) => {
+      const trimmed = value.trim()
+      if (!trimmed) return
+      onSubmit?.(trimmed, activeLocale)
+    },
+    [onSubmit, activeLocale]
+  )
+
+  const handleFormSubmit = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault()
+      const selected =
+        highlightedIndex >= 0 && highlightedIndex < suggestions.length
+          ? suggestions[highlightedIndex].title
+          : query
+      submitQuery(selected)
+    },
+    [highlightedIndex, suggestions, query, submitQuery]
+  )
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLInputElement>) => {
+      if (!suggestions.length) return
+      if (event.key === 'ArrowDown') {
+        event.preventDefault()
+        setHighlightedIndex((index) => (index + 1) % suggestions.length)
+      } else if (event.key === 'ArrowUp') {
+        event.preventDefault()
+        setHighlightedIndex((index) => (index - 1 + suggestions.length) % suggestions.length)
+      } else if (event.key === 'Enter') {
+        const selected =
+          highlightedIndex >= 0 && highlightedIndex < suggestions.length
+            ? suggestions[highlightedIndex].title
+            : query
+        submitQuery(selected)
+      }
+    },
+    [suggestions, highlightedIndex, query, submitQuery]
+  )
+
+  const handleSuggestionClick = useCallback(
+    (title: string) => {
+      submitQuery(title)
+    },
+    [submitQuery]
+  )
+
+  return (
+    <AnimatePresence>
+      {open ? (
+        <motion.section
+          id={id}
+          aria-labelledby={`${inputId}-label`}
+          initial={shouldReduceMotion ? false : { height: 0, opacity: 0 }}
+          animate={shouldReduceMotion ? { height: 'auto', opacity: 1 } : { height: 'auto', opacity: 1 }}
+          exit={shouldReduceMotion ? { height: 0, opacity: 0 } : { height: 0, opacity: 0 }}
+          transition={shouldReduceMotion ? { duration: 0 } : { duration: 0.2, ease: 'easeInOut' }}
+          className={classNames('overflow-hidden bg-white shadow-lg border-t border-neutral-200', className)}
+        >
+          <div ref={panelRef} className="px-4 py-6 md:px-6">
+            <form onSubmit={handleFormSubmit} className="space-y-4">
+              <div>
+                <label id={`${inputId}-label`} htmlFor={inputId} className="sr-only">
+                  Search
+                </label>
+                <input
+                  ref={inputRef}
+                  id={inputId}
+                  type="text"
+                  role="combobox"
+                  aria-autocomplete="list"
+                  aria-expanded={suggestions.length > 0}
+                  aria-controls={listboxId}
+                  value={query}
+                  onChange={(event) => setQuery(event.target.value)}
+                  onKeyDown={handleKeyDown}
+                  placeholder="Search for properties or guides"
+                  className="w-full rounded-md border border-neutral-300 px-4 py-2 text-base focus:outline-none focus:ring-2 focus:ring-primary-500"
+                />
+              </div>
+              <div>
+                <button
+                  type="submit"
+                  className="inline-flex items-center rounded-md bg-primary-600 px-4 py-2 text-white hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500"
+                >
+                  Search
+                </button>
+              </div>
+            </form>
+            <div className="mt-4">
+              {loading && <p className="text-sm text-neutral-500">Loading suggestions…</p>}
+              {error && <p className="text-sm text-red-600">{error}</p>}
+              {suggestions.length > 0 && (
+                <ul
+                  id={listboxId}
+                  role="listbox"
+                  className="mt-2 max-h-64 overflow-y-auto divide-y divide-neutral-200 border border-neutral-200 rounded-md"
+                >
+                  {suggestions.map((item, index) => (
+                    <li
+                      key={`${item.title}-${index}`}
+                      role="option"
+                      aria-selected={highlightedIndex === index}
+                      className={classNames(
+                        'flex cursor-pointer items-center gap-4 px-4 py-3 transition-colors',
+                        highlightedIndex === index ? 'bg-primary-50' : 'bg-white'
+                      )}
+                      onMouseEnter={() => setHighlightedIndex(index)}
+                      onMouseDown={(event) => event.preventDefault()}
+                      onClick={() => handleSuggestionClick(item.title)}
+                    >
+                      <img
+                        src={item.image}
+                        alt=""
+                        width={48}
+                        height={48}
+                        className="h-12 w-12 flex-shrink-0 rounded object-cover"
+                      />
+                      <span className="text-sm font-medium text-neutral-900">{item.title}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+              {!loading && !error && query.trim() && suggestions.length === 0 && (
+                <p className="text-sm text-neutral-500">No matches found.</p>
+              )}
+            </div>
+          </div>
+        </motion.section>
+      ) : null}
+    </AnimatePresence>
+  )
+}

--- a/src/views/search/SearchPageContent.tsx
+++ b/src/views/search/SearchPageContent.tsx
@@ -1,3 +1,162 @@
+import Link from 'next/link'
+import { useCallback, useEffect, useMemo, useState, type FormEvent } from 'react'
+import { useRouter } from 'next/router'
+import { normalizeSearchLocale } from '@/components/search/SearchPanel'
+
+interface ResultItem {
+  title: string
+  image: string
+}
+
+const PLACEHOLDER_IMAGE = '/images/placeholder.jpg'
+
+type FetchStatus = 'idle' | 'loading' | 'error' | 'success'
+
 export default function SearchPageContent() {
-  return <h1>Search</h1>
+  const router = useRouter()
+  const activeLocale = useMemo(() => {
+    const paramLocale = Array.isArray(router.query?.locale)
+      ? router.query?.locale[0]
+      : router.query?.locale
+    return normalizeSearchLocale(paramLocale ?? router.locale ?? router.defaultLocale ?? 'en')
+  }, [router.query?.locale, router.locale, router.defaultLocale])
+  const [inputValue, setInputValue] = useState('')
+  const [submittedQuery, setSubmittedQuery] = useState('')
+  const [results, setResults] = useState<ResultItem[]>([])
+  const [status, setStatus] = useState<FetchStatus>('idle')
+  const [errorMessage, setErrorMessage] = useState('')
+
+  useEffect(() => {
+    if (!router.isReady) return
+    const param = router.query?.q
+    const value = Array.isArray(param) ? param[0] ?? '' : param ?? ''
+    setInputValue(value)
+    setSubmittedQuery(value.trim())
+  }, [router.isReady, router.query?.q])
+
+  useEffect(() => {
+    if (!submittedQuery) {
+      setStatus('idle')
+      setResults([])
+      setErrorMessage('')
+      return
+    }
+    const controller = new AbortController()
+    setStatus('loading')
+    setErrorMessage('')
+    fetch(`/api/suggest?locale=${activeLocale}&q=${encodeURIComponent(submittedQuery)}`, {
+      signal: controller.signal,
+    })
+      .then((response) => {
+        if (!response.ok) throw new Error('Failed to fetch results')
+        return response.json() as Promise<{ suggestions?: string[] }>
+      })
+      .then((data) => {
+        const items = (data.suggestions ?? []).map((title) => ({
+          title,
+          image: PLACEHOLDER_IMAGE,
+        }))
+        setResults(items)
+        setStatus('success')
+      })
+      .catch((error) => {
+        if (error?.name === 'AbortError') return
+        setErrorMessage('Something went wrong while loading results. Please try again.')
+        setStatus('error')
+        setResults([])
+      })
+    return () => {
+      controller.abort()
+    }
+  }, [submittedQuery, activeLocale])
+
+  const handleSubmit = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault()
+      const trimmed = inputValue.trim()
+      if (!trimmed) {
+        setSubmittedQuery('')
+        setResults([])
+        setStatus('idle')
+        return
+      }
+      const destination = `/${activeLocale}/search?q=${encodeURIComponent(trimmed)}`
+      if (router.asPath === destination) {
+        setSubmittedQuery(trimmed)
+        return
+      }
+      setSubmittedQuery(trimmed)
+      router.push(destination)
+    },
+    [inputValue, activeLocale, router]
+  )
+
+  return (
+    <div className="px-4 py-10 md:py-16">
+      <div className="mx-auto w-full max-w-3xl">
+        <h1 className="text-3xl font-semibold text-neutral-900">Search</h1>
+        <form onSubmit={handleSubmit} className="mt-6 flex flex-col gap-4 md:flex-row">
+          <label className="sr-only" htmlFor="search-input">
+            Search
+          </label>
+          <input
+            id="search-input"
+            type="text"
+            value={inputValue}
+            onChange={(event) => setInputValue(event.target.value)}
+            placeholder="Search for properties or guides"
+            className="flex-1 rounded-md border border-neutral-300 px-4 py-2 text-base focus:outline-none focus:ring-2 focus:ring-primary-500"
+          />
+          <button
+            type="submit"
+            className="inline-flex items-center justify-center rounded-md bg-primary-600 px-4 py-2 text-white hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500"
+          >
+            Search
+          </button>
+        </form>
+        <div className="mt-8 space-y-4">
+          {status === 'idle' && !submittedQuery && (
+            <p className="text-neutral-500">Start typing to discover listings, guides, and more.</p>
+          )}
+          {status === 'loading' && <p className="text-neutral-500">Loading results…</p>}
+          {status === 'error' && <p className="text-red-600">{errorMessage}</p>}
+          {status === 'success' && results.length === 0 && (
+            <p className="text-neutral-500">
+              No results found for <span className="font-semibold">{submittedQuery}</span>.
+            </p>
+          )}
+          {results.length > 0 && (
+            <ul className="divide-y divide-neutral-200 rounded-md border border-neutral-200">
+              {results.map((item) => {
+                const href = `/${activeLocale}/search?q=${encodeURIComponent(item.title)}`
+                return (
+                  <li key={item.title} className="flex items-center gap-4 px-4 py-3">
+                    <img
+                      src={item.image}
+                      alt=""
+                      width={64}
+                      height={64}
+                      className="h-16 w-16 flex-shrink-0 rounded object-cover"
+                    />
+                    <div className="flex-1">
+                      <Link
+                        href={href}
+                        className="text-lg font-medium text-primary-700 hover:underline"
+                        onClick={() => {
+                          setSubmittedQuery(item.title)
+                          setInputValue(item.title)
+                        }}
+                      >
+                        {item.title}
+                      </Link>
+                    </div>
+                  </li>
+                )
+              })}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
+  )
 }

--- a/test/SearchPanel.test.js
+++ b/test/SearchPanel.test.js
@@ -1,0 +1,95 @@
+const path = require('path')
+
+require('ts-node').register({
+  transpileOnly: true,
+  project: path.resolve(__dirname, '../tsconfig.json'),
+  compilerOptions: { jsx: 'react-jsx', module: 'commonjs' },
+})
+require('tsconfig-paths/register')
+
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const React = require('react')
+const { JSDOM } = require('jsdom')
+
+const dom = new JSDOM('<!doctype html><html><body></body></html>', {
+  url: 'http://localhost/',
+})
+
+globalThis.window = dom.window
+globalThis.document = dom.window.document
+globalThis.navigator = dom.window.navigator
+globalThis.HTMLElement = dom.window.HTMLElement
+globalThis.Element = dom.window.Element
+global.document = dom.window.document
+global.window = dom.window
+global.navigator = dom.window.navigator
+
+globalThis.requestAnimationFrame =
+  dom.window.requestAnimationFrame?.bind(dom.window) || ((cb) => setTimeout(cb, 0))
+globalThis.cancelAnimationFrame =
+  dom.window.cancelAnimationFrame?.bind(dom.window) || ((id) => clearTimeout(id))
+
+if (!window.matchMedia) {
+  window.matchMedia = () => ({
+    matches: false,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  })
+}
+
+if (!window.scrollTo) {
+  window.scrollTo = () => {}
+}
+
+if (!dom.window.HTMLElement.prototype.attachEvent) {
+  dom.window.HTMLElement.prototype.attachEvent = () => {}
+  dom.window.HTMLElement.prototype.detachEvent = () => {}
+}
+
+window.scrollTo = () => {}
+
+const { render, screen, fireEvent } = require('@testing-library/react')
+
+test('SearchPanel submits the highlighted suggestion with locale normalization', async (t) => {
+  const originalFetch = global.fetch
+  const calls = []
+  global.fetch = (input) => {
+    calls.push(input.toString())
+    return Promise.resolve({
+      ok: true,
+      json: async () => ({ suggestions: ['Bangkok Condo', 'Bangkok House'] }),
+    })
+  }
+
+  t.after(() => {
+    global.fetch = originalFetch
+  })
+
+  const SearchPanel = require('../src/components/search/SearchPanel').default
+
+  let submitted = null
+  render(
+    React.createElement(SearchPanel, {
+      open: true,
+      locale: 'TH',
+      onClose: () => {},
+      onSubmit: (value, locale) => {
+        submitted = { value, locale }
+      },
+    })
+  )
+
+  const input = screen.getByRole('combobox', { name: 'Search' })
+  fireEvent.change(input, { target: { value: 'Bang' } })
+  await new Promise((resolve) => setTimeout(resolve, 350))
+  const options = await screen.findAllByRole('option')
+  assert.equal(options.length, 2)
+
+  fireEvent.keyDown(input, { key: 'ArrowDown' })
+  fireEvent.keyDown(input, { key: 'Enter' })
+
+  assert.deepEqual(submitted, { value: 'Bangkok House', locale: 'th' })
+  assert.ok(calls.some((url) => url.includes('locale=th')))
+  await new Promise((resolve) => setTimeout(resolve, 0))
+})

--- a/test/jsonld.test.js
+++ b/test/jsonld.test.js
@@ -1,4 +1,10 @@
-require('ts-node').register({ transpileOnly: true, compilerOptions: { jsx: 'react-jsx', module: 'commonjs' } });
+const path = require('path');
+require('ts-node').register({
+  transpileOnly: true,
+  project: path.resolve(__dirname, '../tsconfig.json'),
+  compilerOptions: { jsx: 'react-jsx', module: 'commonjs' },
+});
+require('tsconfig-paths/register');
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const React = require('react');
@@ -100,7 +106,19 @@ test('index page JSON-LD escapes unsafe characters', () => {
   };
 
   const Home = require('../pages/index').default;
-  const html = renderToStaticMarkup(React.createElement(Home));
+  const props = {
+    head: {
+      seo: { title: '', description: '', canonical: '', languageAlternates: [], openGraph: {}, additionalMetaTags: [] },
+      webPage: { id: '', url: '', title: '', description: '' },
+      breadcrumb: [],
+      localBusiness: {},
+      websiteJson: {},
+      speakableJson: { speakable: { '@type': 'SpeakableSpecification' } },
+    },
+    keywords: [],
+    lang: 'en',
+  };
+  const html = renderToStaticMarkup(React.createElement(Home, props));
   Module.prototype.require = originalRequire;
   const match = html.match(/<script id="speakable"[^>]*>([\s\S]*?)<\/script>/);
   assert.ok(match);
@@ -156,7 +174,19 @@ test('index page JSON-LD includes SpeakableSpecification', () => {
   };
 
   const Home = require('../pages/index').default;
-  const html = renderToStaticMarkup(React.createElement(Home));
+  const props = {
+    head: {
+      seo: { title: '', description: '', canonical: '', languageAlternates: [], openGraph: {}, additionalMetaTags: [] },
+      webPage: { id: '', url: '', title: '', description: '' },
+      breadcrumb: [],
+      localBusiness: {},
+      websiteJson: {},
+      speakableJson: { speakable: { '@type': 'SpeakableSpecification' } },
+    },
+    keywords: [],
+    lang: 'en',
+  };
+  const html = renderToStaticMarkup(React.createElement(Home, props));
   Module.prototype.require = originalRequire;
   const match = html.match(/<script id="speakable"[^>]*>([\s\S]*?)<\/script>/);
   assert.ok(match);


### PR DESCRIPTION
## Summary
- add a header search toggle that sends queries to the locale-aware search route
- implement an animated SearchPanel component with suggestion fetching and keyboard navigation
- expand the search page and supporting tests for autocomplete behavior

## Testing
- node --test

------
https://chatgpt.com/codex/tasks/task_e_68cc229db8c4832b9b9dafa20f35e444