### PR TITLE
Enhance menu accessibility and add interaction tests

### DIFF
--- a/components/MegaMenu.tsx
+++ b/components/MegaMenu.tsx
@@ -1,4 +1,5 @@
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef, useEffect, useId, useCallback } from 'react'
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion'
 import Link from 'next/link'
 import { NavItem } from '@/config/nav'
 
@@ -10,6 +11,11 @@ export default function MegaMenu({ item }: MegaMenuProps) {
   const [open, setOpen] = useState(false)
   const buttonRef = useRef<HTMLButtonElement>(null)
   const menuRef = useRef<HTMLDivElement>(null)
+  const menuItemsRef = useRef<HTMLElement[]>([])
+  const id = useId()
+  const menuId = `${id}-menu`
+  const buttonId = `${id}-trigger`
+  const shouldReduceMotion = useReducedMotion()
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
@@ -36,12 +42,56 @@ export default function MegaMenu({ item }: MegaMenuProps) {
   }, [open])
 
   useEffect(() => {
-    if (open) menuRef.current?.querySelector('a')?.focus()
+    if (!open) {
+      menuItemsRef.current = []
+      return
+    }
+
+    const items = Array.from(
+      menuRef.current?.querySelectorAll<HTMLElement>('[role="menuitem"]') ?? []
+    )
+
+    menuItemsRef.current = items
+
+    if (items.length > 0) {
+      const focusTarget = items[0]
+      // Delay focus slightly to ensure elements are mounted when animations run
+      if (typeof requestAnimationFrame === 'function') {
+        requestAnimationFrame(() => focusTarget.focus())
+      } else {
+        focusTarget.focus()
+      }
+    }
   }, [open])
 
-  const prefersReduced =
-    typeof window !== 'undefined' &&
-    window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  const handleMenuKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      const { key } = event
+      const items = menuItemsRef.current
+
+      if (!items.length) return
+
+      const currentIndex = items.findIndex((item) => item === document.activeElement)
+      const lastIndex = items.length - 1
+
+      if (key === 'ArrowDown' || key === 'ArrowRight') {
+        event.preventDefault()
+        const nextIndex = currentIndex >= 0 ? (currentIndex + 1) % items.length : 0
+        items[nextIndex].focus()
+      } else if (key === 'ArrowUp' || key === 'ArrowLeft') {
+        event.preventDefault()
+        const prevIndex = currentIndex >= 0 ? (currentIndex - 1 + items.length) % items.length : lastIndex
+        items[prevIndex].focus()
+      } else if (key === 'Home') {
+        event.preventDefault()
+        items[0].focus()
+      } else if (key === 'End') {
+        event.preventDefault()
+        items[lastIndex].focus()
+      }
+    },
+    []
+  )
 
   const hasSections = item.sections && item.sections.length > 0
 
@@ -51,62 +101,71 @@ export default function MegaMenu({ item }: MegaMenuProps) {
         ref={buttonRef}
         aria-haspopup="true"
         aria-expanded={open}
+        id={buttonId}
+        aria-controls={menuId}
         onClick={() => hasSections && setOpen((value) => !value)}
         disabled={!hasSections}
       >
         {item.title}
       </button>
-      {open && hasSections && (
-        <div
-          ref={menuRef}
-          role="menu"
-          className={`absolute left-1/2 z-20 mt-2 w-screen max-w-4xl -translate-x-1/2 rounded-md border border-gray-200 bg-white shadow-lg focus:outline-none ${
-            prefersReduced ? '' : 'transition-opacity duration-200'
-          }`}
-        >
-          <div className="grid gap-6 p-6 sm:grid-cols-2 lg:grid-cols-3">
-            {item.href && (
-              <div className="sm:col-span-2 lg:col-span-3">
-                <Link
-                  href={item.href}
-                  className="inline-flex items-center gap-2 text-sm font-semibold text-blue-600 hover:text-blue-500"
-                  onClick={() => setOpen(false)}
-                >
-                  View all {item.title}
-                </Link>
-                {item.description && (
-                  <p className="mt-1 text-sm text-gray-600">{item.description}</p>
-                )}
-              </div>
-            )}
-            {item.sections?.map((section) => (
-              <div key={section.title} className="space-y-2">
-                <p className="text-sm font-semibold text-gray-900">{section.title}</p>
-                {section.description && (
-                  <p className="text-xs text-gray-600">{section.description}</p>
-                )}
-                <ul className="space-y-2">
-                  {section.items.map((link) => (
-                    <li key={link.title} role="none">
-                      <Link
-                        role="menuitem"
-                        href={link.href}
-                        className="block rounded-md px-3 py-2 text-sm text-gray-700 transition hover:bg-gray-50 hover:text-gray-900"
-                        onClick={() => setOpen(false)}
-                      >
-                        <span className="font-medium">{link.title}</span>
-                        {link.description && (
-                          <span className="mt-1 block text-xs text-gray-500">{link.description}</span>
-                        )}
-                      </Link>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
+      <AnimatePresence>
+        {open && hasSections && (
+          <motion.div
+            id={menuId}
+            ref={menuRef}
+            role="menu"
+            aria-labelledby={buttonId}
+            onKeyDown={handleMenuKeyDown}
+            initial={{ opacity: 0, scale: shouldReduceMotion ? 1 : 0.98 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: shouldReduceMotion ? 1 : 0.98 }}
+            transition={{ duration: 0.14, ease: 'easeOut' }}
+            className="absolute left-1/2 z-20 mt-2 w-screen max-w-4xl -translate-x-1/2 rounded-md border border-gray-200 bg-white shadow-lg focus:outline-none"
+          >
+            <div className="grid gap-6 p-6 sm:grid-cols-2 lg:grid-cols-3">
+              {item.href && (
+                <div className="sm:col-span-2 lg:col-span-3">
+                  <Link
+                    href={item.href}
+                    className="inline-flex items-center gap-2 text-sm font-semibold text-blue-600 hover:text-blue-500"
+                    onClick={() => setOpen(false)}
+                  >
+                    View all {item.title}
+                  </Link>
+                  {item.description && (
+                    <p className="mt-1 text-sm text-gray-600">{item.description}</p>
+                  )}
+                </div>
+              )}
+              {item.sections?.map((section) => (
+                <div key={section.title} className="space-y-2">
+                  <p className="text-sm font-semibold text-gray-900">{section.title}</p>
+                  {section.description && (
+                    <p className="text-xs text-gray-600">{section.description}</p>
+                  )}
+                  <ul className="space-y-2" role="none">
+                    {section.items.map((link) => (
+                      <li key={link.title} role="none">
+                        <Link
+                          role="menuitem"
+                          href={link.href}
+                          className="block rounded-md px-3 py-2 text-sm text-gray-700 transition hover:bg-gray-50 hover:text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                          onClick={() => setOpen(false)}
+                        >
+                          <span className="font-medium">{link.title}</span>
+                          {link.description && (
+                            <span className="mt-1 block text-xs text-gray-500">{link.description}</span>
+                          )}
+                        </Link>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ))}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </div>
   )
 }

--- a/components/MobileMenu.tsx
+++ b/components/MobileMenu.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useCallback } from 'react'
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion'
 import Link from 'next/link'
 import { NavItem } from '@/config/nav'
 
@@ -11,6 +12,8 @@ interface MobileMenuProps {
 
 export default function MobileMenu({ open, onClose, items, children }: MobileMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null)
+  const closeButtonRef = useRef<HTMLButtonElement>(null)
+  const shouldReduceMotion = useReducedMotion()
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
@@ -23,87 +26,149 @@ export default function MobileMenu({ open, onClose, items, children }: MobileMen
   }, [open, onClose])
 
   useEffect(() => {
-    if (open) {
-      const first = menuRef.current?.querySelector<HTMLElement>('a,button,select,input,textarea')
-      first && typeof first.focus === 'function' && first.focus()
+    if (!open) return
+
+    const focusables = menuRef.current?.querySelectorAll<HTMLElement>(
+      'a, button, select, textarea, input, [tabindex]:not([tabindex="-1"])'
+    )
+
+    if (focusables && focusables.length > 0) {
+      const focusTarget = closeButtonRef.current ?? focusables[0]
+
+      if (typeof requestAnimationFrame === 'function') {
+        requestAnimationFrame(() => focusTarget.focus())
+      } else {
+        focusTarget.focus()
+      }
     }
   }, [open])
 
-  if (!open) return null
+  const handleFocusTrap = useCallback(
+    (event: KeyboardEvent) => {
+      if (!open || event.key !== 'Tab') return
 
-  const prefersReduced =
-    typeof window !== 'undefined' &&
-    window.matchMedia('(prefers-reduced-motion: reduce)').matches
+      const focusables = Array.from(
+        menuRef.current?.querySelectorAll<HTMLElement>(
+          'a, button, select, textarea, input, [tabindex]:not([tabindex="-1"])'
+        ) ?? []
+      ).filter((element) => !element.hasAttribute('disabled'))
+
+      if (!focusables.length) return
+
+      const first = focusables[0]
+      const last = focusables[focusables.length - 1]
+      const active = document.activeElement as HTMLElement | null
+
+      if (!event.shiftKey && active === last) {
+        event.preventDefault()
+        first.focus()
+      } else if (event.shiftKey && active === first) {
+        event.preventDefault()
+        last.focus()
+      }
+    },
+    [open]
+  )
+
+  useEffect(() => {
+    if (!open) return
+    document.addEventListener('keydown', handleFocusTrap)
+    return () => document.removeEventListener('keydown', handleFocusTrap)
+  }, [open, handleFocusTrap])
 
   return (
-    <div
-      id="mobile-menu"
-      ref={menuRef}
-      role="dialog"
-      aria-modal="true"
-      className={`md:hidden fixed inset-0 bg-white p-4 overflow-auto ${
-        prefersReduced ? '' : 'transition-transform duration-200'
-      }`}
-    >
-      <button onClick={onClose} className="mb-4 text-sm font-semibold text-gray-600">
-        Close
-      </button>
-      <ul className="flex flex-col gap-6" role="menu">
-        {items.map((item) => {
-          const hasSections = item.sections && item.sections.length > 0
-          return (
-            <li key={item.title} role="none" className="space-y-3">
-              {item.href ? (
-                <Link
-                  href={item.href}
-                  role="menuitem"
-                  className="text-lg font-semibold"
-                  onClick={onClose}
-                >
-                  {item.title}
-                </Link>
-              ) : (
-                <span className="text-lg font-semibold" role="presentation">
-                  {item.title}
-                </span>
-              )}
-              {item.description && (
-                <p className="text-sm text-gray-600">{item.description}</p>
-              )}
-              {hasSections && (
-                <div className="space-y-4" role="group" aria-label={`${item.title} sections`}>
-                  {item.sections!.map((section) => (
-                    <div key={section.title} className="rounded-lg border border-gray-100 bg-gray-50 p-3">
-                      <p className="text-sm font-semibold text-gray-900">{section.title}</p>
-                      {section.description && (
-                        <p className="mt-1 text-xs text-gray-600">{section.description}</p>
-                      )}
-                      <ul className="mt-2 space-y-2" role="menu">
-                        {section.items.map((link) => (
-                          <li key={link.title} role="none">
-                            <Link
-                              href={link.href}
-                              role="menuitem"
-                              className="block rounded-md px-3 py-2 text-sm text-gray-700 hover:bg-white hover:text-gray-900"
-                              onClick={onClose}
-                            >
-                              <span className="font-medium">{link.title}</span>
-                              {link.description && (
-                                <span className="mt-1 block text-xs text-gray-500">{link.description}</span>
-                              )}
-                            </Link>
-                          </li>
+    <AnimatePresence>
+      {open && (
+        <div className="md:hidden fixed inset-0 z-40">
+          <motion.div
+            className="absolute inset-0 bg-black/40"
+            onClick={onClose}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.16, ease: 'easeOut' }}
+          />
+          <motion.div
+            id="mobile-menu"
+            ref={menuRef}
+            role="dialog"
+            aria-modal="true"
+            initial={{ opacity: 0, x: shouldReduceMotion ? 0 : 16 }}
+            animate={{ opacity: 1, x: 0 }}
+            exit={{ opacity: 0, x: shouldReduceMotion ? 0 : 16 }}
+            transition={{ duration: 0.16, ease: 'easeOut' }}
+            className="relative ml-auto flex h-full w-full max-w-sm flex-col overflow-auto bg-white p-4 shadow-xl"
+          >
+            <button
+              ref={closeButtonRef}
+              onClick={onClose}
+              className="mb-4 self-end text-sm font-semibold text-gray-600 hover:text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+            >
+              Close
+            </button>
+            <ul className="flex flex-col gap-6" role="menu">
+              {items.map((item) => {
+                const hasSections = item.sections && item.sections.length > 0
+                return (
+                  <li key={item.title} role="none" className="space-y-3">
+                    {item.href ? (
+                      <Link
+                        href={item.href}
+                        role="menuitem"
+                        className="text-lg font-semibold"
+                        onClick={onClose}
+                      >
+                        {item.title}
+                      </Link>
+                    ) : (
+                      <span className="text-lg font-semibold" role="presentation">
+                        {item.title}
+                      </span>
+                    )}
+                    {item.description && (
+                      <p className="text-sm text-gray-600">{item.description}</p>
+                    )}
+                    {hasSections && (
+                      <div className="space-y-4" role="group" aria-label={`${item.title} sections`}>
+                        {item.sections!.map((section) => (
+                          <div key={section.title} className="rounded-lg border border-gray-100 bg-gray-50 p-3">
+                            <p className="text-sm font-semibold text-gray-900">{section.title}</p>
+                            {section.description && (
+                              <p className="mt-1 text-xs text-gray-600">{section.description}</p>
+                            )}
+                            <ul className="mt-2 space-y-2" role="menu">
+                              {section.items.map((link) => (
+                                <li key={link.title} role="none">
+                                  <Link
+                                    href={link.href}
+                                    role="menuitem"
+                                    className="block rounded-md px-3 py-2 text-sm text-gray-700 hover:bg-white hover:text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                                    onClick={onClose}
+                                  >
+                                    <span className="font-medium">{link.title}</span>
+                                    {link.description && (
+                                      <span className="mt-1 block text-xs text-gray-500">{link.description}</span>
+                                    )}
+                                  </Link>
+                                </li>
+                              ))}
+                            </ul>
+                          </div>
                         ))}
-                      </ul>
-                    </div>
-                  ))}
-                </div>
+                      </div>
+                    )}
+                  </li>
+                )
+              })}
+              {children && (
+                <li role="none" className="mt-2 flex flex-wrap items-center gap-4">
+                  {children}
+                </li>
               )}
-            </li>
-          )
-        })}
-        {children && <li role="none" className="mt-2 flex flex-wrap gap-4 items-center">{children}</li>}
-      </ul>
-    </div>
+            </ul>
+          </motion.div>
+        </div>
+      )}
+    </AnimatePresence>
   )
 }

--- a/test/MegaMenu.test.js
+++ b/test/MegaMenu.test.js
@@ -1,0 +1,132 @@
+require('ts-node').register({ transpileOnly: true, compilerOptions: { jsx: 'react-jsx', module: 'commonjs' } })
+
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const React = require('react')
+const { JSDOM } = require('jsdom')
+
+const dom = new JSDOM('<!doctype html><html><body></body></html>', {
+  url: 'http://localhost/'
+})
+
+globalThis.window = dom.window
+;['document', 'navigator', 'Node', 'HTMLElement', 'Element'].forEach((key) => {
+  globalThis[key] = dom.window[key]
+})
+
+if (!globalThis.window.matchMedia) {
+  globalThis.window.matchMedia = () => ({
+    matches: false,
+    media: '',
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false
+  })
+}
+
+globalThis.matchMedia = globalThis.window.matchMedia
+
+if (!globalThis.window.requestAnimationFrame) {
+  globalThis.window.requestAnimationFrame = (callback) =>
+    setTimeout(() => callback(Date.now()), 16)
+  globalThis.requestAnimationFrame = globalThis.window.requestAnimationFrame
+}
+
+if (!globalThis.window.cancelAnimationFrame) {
+  globalThis.window.cancelAnimationFrame = (id) => clearTimeout(id)
+  globalThis.cancelAnimationFrame = globalThis.window.cancelAnimationFrame
+}
+
+const { render, screen, fireEvent, within } = require('@testing-library/react')
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+test('MegaMenu supports roving focus with arrow keys and closes on Escape', async () => {
+  const Module = require('module')
+  const originalRequire = Module.prototype.require
+  Module.prototype.require = function (request) {
+    if (request === 'next/link') {
+      return ({ children, href, ...props }) =>
+        React.createElement('a', { ...props, href }, children)
+    }
+    if (request === 'framer-motion') {
+      return {
+        AnimatePresence: ({ children }) => React.createElement(React.Fragment, null, children),
+        motion: new Proxy(
+          {},
+          {
+            get: (_, tag) =>
+              React.forwardRef(({ children: motionChildren, ...rest }, ref) =>
+                React.createElement(String(tag), { ref, ...rest }, motionChildren)
+              )
+          }
+        ),
+        useReducedMotion: () => false
+      }
+    }
+    return originalRequire.apply(this, arguments)
+  }
+
+  let cleanup
+  try {
+    const MegaMenu = require('../components/MegaMenu').default
+
+    const item = {
+      title: 'Services',
+      description: 'All services',
+      sections: [
+        {
+          title: 'Group 1',
+          items: [
+            { title: 'First item', href: '/first' },
+            { title: 'Second item', href: '/second' }
+          ]
+        },
+        {
+          title: 'Group 2',
+          items: [{ title: 'Third item', href: '/third' }]
+        }
+      ]
+    }
+
+    const { unmount } = render(React.createElement(MegaMenu, { item }))
+    cleanup = unmount
+
+    const trigger = screen.getByRole('button', { name: 'Services' })
+    fireEvent.click(trigger)
+
+    const menu = await screen.findByRole('menu')
+    await tick()
+
+    const firstItem = within(menu).getByRole('menuitem', { name: 'First item' })
+    firstItem.focus()
+    assert.strictEqual(document.activeElement, firstItem)
+
+    fireEvent.keyDown(menu, { key: 'ArrowDown' })
+    const secondItem = within(menu).getByRole('menuitem', { name: 'Second item' })
+    assert.strictEqual(document.activeElement, secondItem)
+
+    fireEvent.keyDown(menu, { key: 'ArrowRight' })
+    const thirdItem = within(menu).getByRole('menuitem', { name: 'Third item' })
+    assert.strictEqual(document.activeElement, thirdItem)
+
+    fireEvent.keyDown(menu, { key: 'Home' })
+    assert.strictEqual(document.activeElement, firstItem)
+
+    fireEvent.keyDown(menu, { key: 'End' })
+    assert.strictEqual(document.activeElement, thirdItem)
+
+    fireEvent.keyDown(menu, { key: 'ArrowUp' })
+    assert.strictEqual(document.activeElement, secondItem)
+
+    fireEvent.keyDown(menu, { key: 'Escape' })
+    await tick()
+    assert.strictEqual(document.activeElement, trigger)
+  } finally {
+    if (typeof cleanup === 'function') {
+      cleanup()
+    }
+    Module.prototype.require = originalRequire
+  }
+})

--- a/test/MobileMenu.test.js
+++ b/test/MobileMenu.test.js
@@ -1,0 +1,139 @@
+require('ts-node').register({ transpileOnly: true, compilerOptions: { jsx: 'react-jsx', module: 'commonjs' } })
+
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const React = require('react')
+const { JSDOM } = require('jsdom')
+
+const dom = new JSDOM('<!doctype html><html><body></body></html>', {
+  url: 'http://localhost/'
+})
+
+globalThis.window = dom.window
+;['document', 'navigator', 'Node', 'HTMLElement', 'Element'].forEach((key) => {
+  globalThis[key] = dom.window[key]
+})
+
+if (!globalThis.window.matchMedia) {
+  globalThis.window.matchMedia = () => ({
+    matches: false,
+    media: '',
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false
+  })
+}
+
+globalThis.matchMedia = globalThis.window.matchMedia
+
+if (!globalThis.window.requestAnimationFrame) {
+  globalThis.window.requestAnimationFrame = (callback) =>
+    setTimeout(() => callback(Date.now()), 16)
+  globalThis.requestAnimationFrame = globalThis.window.requestAnimationFrame
+}
+
+if (!globalThis.window.cancelAnimationFrame) {
+  globalThis.window.cancelAnimationFrame = (id) => clearTimeout(id)
+  globalThis.cancelAnimationFrame = globalThis.window.cancelAnimationFrame
+}
+
+const { render, screen, fireEvent, within } = require('@testing-library/react')
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+test('MobileMenu traps focus while open', async () => {
+  const Module = require('module')
+  const originalRequire = Module.prototype.require
+  let cleanup
+  Module.prototype.require = function (request) {
+    if (request === 'next/link') {
+      return ({ children, href, ...props }) =>
+        React.createElement('a', { ...props, href }, children)
+    }
+    if (request === 'framer-motion') {
+      return {
+        AnimatePresence: ({ children }) => React.createElement(React.Fragment, null, children),
+        motion: new Proxy(
+          {},
+          {
+            get: (_, tag) =>
+              React.forwardRef(({ children: motionChildren, ...rest }, ref) =>
+                React.createElement(String(tag), { ref, ...rest }, motionChildren)
+              )
+          }
+        ),
+        useReducedMotion: () => false
+      }
+    }
+    return originalRequire.apply(this, arguments)
+  }
+
+  try {
+    const MobileMenu = require('../components/MobileMenu').default
+
+    const navItems = [
+      {
+        title: 'Services',
+        href: '/services'
+      },
+      {
+        title: 'Guides',
+        sections: [
+          {
+            title: 'Articles',
+            items: [
+              { title: 'First article', href: '/articles/1' },
+              { title: 'Second article', href: '/articles/2' }
+            ]
+          }
+        ]
+      }
+    ]
+
+    const { unmount } = render(
+      React.createElement(MobileMenu, {
+        open: true,
+        onClose: () => {},
+        items: navItems,
+        children: React.createElement(
+          'button',
+          { type: 'button' },
+          'Extra action'
+        )
+      })
+    )
+    cleanup = unmount
+
+    await tick()
+    await tick()
+
+    const closeButton = screen.getByRole('button', { name: 'Close' })
+    const panel = screen.getByRole('dialog')
+    const focusables = Array.from(
+      panel.querySelectorAll('a, button, select, textarea, input, [tabindex]:not([tabindex="-1"])')
+    )
+    const firstFocusable = focusables[0]
+    const lastFocusable = focusables[focusables.length - 1]
+
+    assert.strictEqual(firstFocusable, closeButton)
+
+    closeButton.focus()
+    assert.strictEqual(document.activeElement, closeButton)
+
+    lastFocusable.focus()
+    fireEvent.keyDown(lastFocusable, { key: 'Tab' })
+    await tick()
+    assert.strictEqual(document.activeElement, closeButton)
+
+    closeButton.focus()
+    fireEvent.keyDown(closeButton, { key: 'Tab', shiftKey: true })
+    await tick()
+    assert.strictEqual(document.activeElement, lastFocusable)
+  } finally {
+    if (typeof cleanup === 'function') {
+      cleanup()
+    }
+    Module.prototype.require = originalRequire
+  }
+})


### PR DESCRIPTION
## Summary
- animate the desktop mega menu while improving aria wiring and arrow key navigation
- add an animated overlaying mobile menu with a manual focus trap and reduced-motion fallback
- cover mega and mobile menus with node:test suites for keyboard navigation and focus trapping

## Testing
- `node --test test`


------
https://chatgpt.com/codex/tasks/task_e_68cc2855e378832b899f5c547b258998