### PR TITLE
Expand property filters and sorting

### DIFF
--- a/src/components/PropertyCard.tsx
+++ b/src/components/PropertyCard.tsx
@@ -1,14 +1,14 @@
 import Link from 'next/link';
 import PropertyImage, { asSrc, ImgLike } from './PropertyImage';
-import { useCurrency } from '../context/CurrencyContext';
+import PropertyPrice from './PropertyPrice';
 import { useAdminPreview } from '../context/AdminPreviewContext';
-import { formatCurrencyTHBBase } from '../lib/fx/convert';
 
 interface Property {
   id: number;
   title: { en: string; th: string; zh?: string };
   price: number;
   images: ImgLike[];
+  status?: string;
 }
 
 interface Props {
@@ -17,20 +17,33 @@ interface Props {
 }
 
 export default function PropertyCard({ property, locale }: Props) {
-  const { currency, rates } = useCurrency();
   const { isPreview, requestInlineEdit } = useAdminPreview();
   let localeKey: 'en' | 'th' | 'zh' = 'en';
   if (locale === 'th' || locale === 'zh') {
     localeKey = locale;
   }
   const title = property.title[localeKey] ?? property.title.en;
-  const main = formatCurrencyTHBBase(property.price, currency, rates);
-  const thb = formatCurrencyTHBBase(property.price, 'THB', rates);
+  const status = property.status?.toUpperCase();
+  const statusLabel = status
+    ? status
+        .replace(/_/g, ' ')
+        .toLowerCase()
+        .replace(/\b\w/g, (char) => char.toUpperCase())
+    : null;
+  const badgeClass =
+    status === 'SOLD'
+      ? 'bg-gray-600 text-white'
+      : status === 'RESERVED'
+      ? 'bg-amber-500 text-black'
+      : 'bg-emerald-500 text-white';
+  const containerClass = `relative border p-2 ${
+    status === 'SOLD' ? 'opacity-80 grayscale' : ''
+  }`;
 
   const src = asSrc(property.images?.[0]);
 
   return (
-    <div className="relative border p-2">
+    <div className={containerClass}>
       {isPreview && (
         <button
           type="button"
@@ -51,11 +64,13 @@ export default function PropertyCard({ property, locale }: Props) {
         <PropertyImage src={src} alt={title} />
         <h3 className="font-semibold mt-2">{title}</h3>
       </Link>
-      <div>
-        <div>{main}</div>
-        {currency !== 'THB' && (
-          <div className="text-sm text-gray-500">≈ {thb}</div>
-        )}
+      {statusLabel && (
+        <span className={`absolute left-2 top-2 rounded px-2 py-1 text-xs font-semibold ${badgeClass}`}>
+          {statusLabel}
+        </span>
+      )}
+      <div className="mt-2">
+        <PropertyPrice priceTHB={property.price} />
       </div>
     </div>
   );

--- a/src/components/PropertyFilters.tsx
+++ b/src/components/PropertyFilters.tsx
@@ -1,20 +1,30 @@
-import { ChangeEvent } from 'react';
+import { ChangeEvent, useMemo } from 'react';
 import { PRICE_OPTIONS } from '../lib/filters/price';
 import { useCurrency } from '../context/CurrencyContext';
 import { formatCurrencyTHBBase, formatPriceTHB } from '../lib/fx/convert';
 import useCachedFetch from '../hooks/useCachedFetch';
 
 export interface Filters {
+  province?: string;
+  district?: string;
+  type?: string;
   minPrice?: number;
   maxPrice?: number;
   beds?: number;
   baths?: number;
+  bedsMin?: number;
+  bedsMax?: number;
+  bathsMin?: number;
+  bathsMax?: number;
+  minArea?: number;
+  maxArea?: number;
   status?: string;
   freshness?: number;
   nearTransit?: boolean;
   furnished?: string;
   sort?: string;
   amenities?: string[];
+  tags?: string[];
   transitLine?: string;
   transitStation?: string;
 }
@@ -22,6 +32,37 @@ export interface Filters {
 interface Props {
   filters: Filters;
   onChange: (filters: Filters) => void;
+}
+
+const COUNT_OPTIONS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+
+const FURNISHING_OPTIONS: { value: string; label: string }[] = [
+  { value: 'FURNISHED', label: 'Furnished' },
+  { value: 'PARTLY_FURNISHED', label: 'Partly Furnished' },
+  { value: 'UNFURNISHED', label: 'Unfurnished' },
+];
+
+const STATUS_OPTIONS: { value: string; label: string }[] = [
+  { value: 'AVAILABLE', label: 'Available' },
+  { value: 'RESERVED', label: 'Reserved' },
+  { value: 'SOLD', label: 'Sold' },
+];
+
+const SORT_OPTIONS: { value: string; label: string }[] = [
+  { value: '', label: 'Recommended' },
+  { value: 'price-asc', label: 'Price: Low to High' },
+  { value: 'price-desc', label: 'Price: High to Low' },
+  { value: 'views-desc', label: 'Most Viewed' },
+  { value: 'updated-desc', label: 'Recently Updated' },
+];
+
+function titleCase(value: string) {
+  return value
+    .replace(/[-_]+/g, ' ')
+    .split(' ')
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(' ');
 }
 
 export default function PropertyFilters({ filters, onChange }: Props) {
@@ -33,28 +74,154 @@ export default function PropertyFilters({ filters, onChange }: Props) {
   const { data: transitData } = useCachedFetch<Record<string, string[]>>(
     '/data/transit-bkk.json'
   );
+  const { data: geoData } = useCachedFetch<Record<string, string[]>>(
+    '/data/geo-th-lite.json'
+  );
+  const { data: manifestData } = useCachedFetch<{
+    shards: { key: string; type?: string }[];
+  }>('/data/index/manifest.json');
 
   const amenitiesList = amenitiesData?.amenities || [];
   const transitLines = transitData || {};
-  const handleNumberChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const { name, value } = e.target;
-    onChange({ ...filters, [name]: value ? Number(value) : undefined });
-  };
+  const provinces = useMemo(() => {
+    if (!geoData) return [];
+    return Object.keys(geoData).sort((a, b) => a.localeCompare(b));
+  }, [geoData]);
+
+  const provinceKey = useMemo(() => {
+    if (!filters.province || !geoData) return undefined;
+    if (geoData[filters.province]) return filters.province;
+    const match = Object.keys(geoData).find(
+      (name) => name.toLowerCase() === filters.province?.toLowerCase()
+    );
+    return match;
+  }, [filters.province, geoData]);
+
+  const districtOptions = useMemo(() => {
+    if (!provinceKey || !geoData) return [];
+    return geoData[provinceKey] ?? [];
+  }, [provinceKey, geoData]);
+
+  const propertyTypes = useMemo(() => {
+    const seen = new Set<string>();
+    const types: { value: string; label: string }[] = [];
+    const addType = (raw?: string) => {
+      const trimmed = raw?.trim();
+      if (!trimmed) return;
+      const normalized = trimmed.toLowerCase();
+      if (seen.has(normalized)) return;
+      seen.add(normalized);
+      types.push({ value: normalized, label: titleCase(trimmed) });
+    };
+    manifestData?.shards?.forEach((shard) => {
+      addType(shard.type);
+      if (shard.key) {
+        const parts = shard.key.split('-');
+        addType(parts[parts.length - 1]);
+      }
+    });
+    if (types.length === 0) {
+      ['condo', 'house', 'land', 'townhouse'].forEach(addType);
+    }
+    return types.sort((a, b) => a.label.localeCompare(b.label));
+  }, [manifestData]);
 
   const handleSelectChange = (e: ChangeEvent<HTMLSelectElement>) => {
     const { name, value } = e.target;
+    if (name === 'type') {
+      onChange({ ...filters, type: value ? value.toLowerCase() : undefined });
+      return;
+    }
+    if (name === 'status') {
+      onChange({ ...filters, status: value ? value.toUpperCase() : undefined });
+      return;
+    }
+    if (name === 'furnished') {
+      onChange({ ...filters, furnished: value ? value.toUpperCase() : undefined });
+      return;
+    }
+    if (name === 'transitLine') {
+      const lineValue = value || undefined;
+      const updated: Filters = { ...filters, transitLine: lineValue };
+      if (!lineValue) {
+        delete updated.transitStation;
+      } else if (
+        filters.transitStation &&
+        !(transitLines[lineValue] || []).includes(filters.transitStation)
+      ) {
+        delete updated.transitStation;
+      }
+      onChange(updated);
+      return;
+    }
     onChange({ ...filters, [name]: value || undefined });
   };
 
   const handleCheckboxChange = (e: ChangeEvent<HTMLInputElement>) => {
     const { name, checked, value } = e.target;
-    if (name === 'amenities') {
-      const set = new Set(filters.amenities || []);
+    if (name === 'amenities' || name === 'tags') {
+      const current = name === 'amenities' ? filters.amenities : filters.tags;
+      const set = new Set(current || []);
       checked ? set.add(value) : set.delete(value);
-      onChange({ ...filters, amenities: Array.from(set) });
+      onChange({ ...filters, [name]: Array.from(set) });
     } else {
       onChange({ ...filters, [name]: checked });
     }
+  };
+
+  const handleProvinceChange = (e: ChangeEvent<HTMLSelectElement>) => {
+    const { value } = e.target;
+    const provinceValue = value || undefined;
+    const updated: Filters = { ...filters, province: provinceValue };
+    if (!provinceValue) {
+      delete updated.district;
+    } else {
+      const availableDistricts = new Set(geoData?.[provinceValue] ?? []);
+      if (filters.district && !availableDistricts.has(filters.district)) {
+        delete updated.district;
+      }
+    }
+    onChange(updated);
+  };
+
+  const handleRangeSelectChange = (e: ChangeEvent<HTMLSelectElement>) => {
+    const { name, value } = e.target;
+    const numeric = value ? Number(value) : undefined;
+    const updated: Filters = { ...filters, [name]: numeric };
+    if (name === 'bedsMin' && numeric !== undefined) {
+      if (filters.bedsMax !== undefined && numeric > filters.bedsMax) {
+        updated.bedsMax = numeric;
+      }
+    } else if (name === 'bedsMax' && numeric !== undefined) {
+      if (filters.bedsMin !== undefined && numeric < filters.bedsMin) {
+        updated.bedsMin = numeric;
+      }
+    } else if (name === 'bathsMin' && numeric !== undefined) {
+      if (filters.bathsMax !== undefined && numeric > filters.bathsMax) {
+        updated.bathsMax = numeric;
+      }
+    } else if (name === 'bathsMax' && numeric !== undefined) {
+      if (filters.bathsMin !== undefined && numeric < filters.bathsMin) {
+        updated.bathsMin = numeric;
+      }
+    }
+    onChange(updated);
+  };
+
+  const handleAreaChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    const numeric = value ? Number(value) : undefined;
+    const updated: Filters = { ...filters, [name]: numeric };
+    if (name === 'minArea' && numeric !== undefined) {
+      if (filters.maxArea !== undefined && numeric > filters.maxArea) {
+        updated.maxArea = numeric;
+      }
+    } else if (name === 'maxArea' && numeric !== undefined) {
+      if (filters.minArea !== undefined && numeric < filters.minArea) {
+        updated.minArea = numeric;
+      }
+    }
+    onChange(updated);
   };
 
   const priceTooltip = (value?: number) =>
@@ -63,7 +230,7 @@ export default function PropertyFilters({ filters, onChange }: Props) {
   const handlePriceChange = (e: ChangeEvent<HTMLSelectElement>) => {
     const { name, value } = e.target;
     const num = value ? Number(value) : undefined;
-    let updated: Filters = { ...filters, [name]: num };
+    const updated: Filters = { ...filters, [name]: num };
     if (name === 'minPrice' && num !== undefined) {
       if (filters.maxPrice !== undefined && num > filters.maxPrice) {
         updated.maxPrice = num;
@@ -81,11 +248,82 @@ export default function PropertyFilters({ filters, onChange }: Props) {
       ? `${priceTooltip(filters.minPrice) ?? 'Any'} – ${priceTooltip(filters.maxPrice) ?? 'Any'}`
       : undefined;
 
+  const bedsOptions = COUNT_OPTIONS.map((value) => ({
+    value,
+    label: value === 0 ? 'Studio' : `${value}+`,
+  }));
+
+  const bathsOptions = COUNT_OPTIONS.map((value) => ({
+    value,
+    label: value === 0 ? 'Any' : `${value}+`,
+  }));
+
   return (
-    <div className="space-y-2">
-      <div title={rangeTooltip}>
-        <label>
-          Min Price
+    <div className="space-y-4">
+      <div className="grid gap-2 md:grid-cols-2">
+        <label className="flex flex-col gap-1">
+          <span className="text-sm font-medium">Province</span>
+          <select name="province" value={filters.province ?? ''} onChange={handleProvinceChange}>
+            <option value="">Any</option>
+            {provinces.map((province) => (
+              <option key={province} value={province}>
+                {province}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-sm font-medium">District</span>
+          <select
+            name="district"
+            value={filters.district ?? ''}
+            onChange={handleSelectChange}
+            disabled={!districtOptions.length}
+          >
+            <option value="">Any</option>
+            {districtOptions.map((district) => (
+              <option key={district} value={district}>
+                {district}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+      <div className="grid gap-2 md:grid-cols-2">
+        <label className="flex flex-col gap-1">
+          <span className="text-sm font-medium">Property Type</span>
+          <select
+            name="type"
+            value={filters.type ? filters.type.toLowerCase() : ''}
+            onChange={handleSelectChange}
+          >
+            <option value="">Any</option>
+            {propertyTypes.map((type) => (
+              <option key={type.value} value={type.value}>
+                {type.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-sm font-medium">Status</span>
+          <select
+            name="status"
+            value={filters.status ? filters.status.toUpperCase() : ''}
+            onChange={handleSelectChange}
+          >
+            <option value="">Any</option>
+            {STATUS_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+      <div className="grid gap-2 md:grid-cols-2" title={rangeTooltip}>
+        <label className="flex flex-col gap-1">
+          <span className="text-sm font-medium">Min Price</span>
           <select
             name="minPrice"
             value={filters.minPrice ?? ''}
@@ -102,8 +340,8 @@ export default function PropertyFilters({ filters, onChange }: Props) {
             ))}
           </select>
         </label>
-        <label>
-          Max Price
+        <label className="flex flex-col gap-1">
+          <span className="text-sm font-medium">Max Price</span>
           <select
             name="maxPrice"
             value={filters.maxPrice ?? ''}
@@ -121,63 +359,139 @@ export default function PropertyFilters({ filters, onChange }: Props) {
           </select>
         </label>
       </div>
-      <div>
-        <label>
-          Beds
-          <input
-            type="number"
-            name="beds"
-            value={filters.beds ?? ''}
-            onChange={handleNumberChange}
-          />
+      <div className="grid gap-2 md:grid-cols-2">
+        <label className="flex flex-col gap-1">
+          <span className="text-sm font-medium">Bedrooms</span>
+          <div className="flex gap-2">
+            <select
+              name="bedsMin"
+              value={filters.bedsMin ?? ''}
+              onChange={handleRangeSelectChange}
+            >
+              <option value="">Min</option>
+              {bedsOptions.map((option) => (
+                <option key={`beds-min-${option.value}`} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+            <select
+              name="bedsMax"
+              value={filters.bedsMax ?? ''}
+              onChange={handleRangeSelectChange}
+            >
+              <option value="">Max</option>
+              {bedsOptions.map((option) => (
+                <option key={`beds-max-${option.value}`} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
         </label>
-        <label>
-          Baths
-          <input
-            type="number"
-            name="baths"
-            value={filters.baths ?? ''}
-            onChange={handleNumberChange}
-          />
+        <label className="flex flex-col gap-1">
+          <span className="text-sm font-medium">Bathrooms</span>
+          <div className="flex gap-2">
+            <select
+              name="bathsMin"
+              value={filters.bathsMin ?? ''}
+              onChange={handleRangeSelectChange}
+            >
+              <option value="">Min</option>
+              {bathsOptions.map((option) => (
+                <option key={`baths-min-${option.value}`} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+            <select
+              name="bathsMax"
+              value={filters.bathsMax ?? ''}
+              onChange={handleRangeSelectChange}
+            >
+              <option value="">Max</option>
+              {bathsOptions.map((option) => (
+                <option key={`baths-max-${option.value}`} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
         </label>
       </div>
-      <div>
-        <label>
-          Status
-          <select name="status" value={filters.status ?? ''} onChange={handleSelectChange}>
-            <option value="">Any</option>
-            <option value="sale">For Sale</option>
-            <option value="rent">For Rent</option>
-          </select>
+      <div className="grid gap-2 md:grid-cols-2">
+        <label className="flex flex-col gap-1">
+          <span className="text-sm font-medium">Area (sqm)</span>
+          <div className="flex gap-2">
+            <input
+              type="number"
+              name="minArea"
+              min={0}
+              value={filters.minArea ?? ''}
+              onChange={handleAreaChange}
+              placeholder="Min"
+            />
+            <input
+              type="number"
+              name="maxArea"
+              min={0}
+              value={filters.maxArea ?? ''}
+              onChange={handleAreaChange}
+              placeholder="Max"
+            />
+          </div>
         </label>
-        <label>
-          Freshness
+        <label className="flex flex-col gap-1">
+          <span className="text-sm font-medium">Furnished</span>
           <select
-            name="freshness"
-            value={filters.freshness ?? ''}
+            name="furnished"
+            value={filters.furnished ? filters.furnished.toUpperCase() : ''}
             onChange={handleSelectChange}
           >
+            <option value="">Any</option>
+            {FURNISHING_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+      <div className="grid gap-2 md:grid-cols-2">
+        <label className="flex flex-col gap-1">
+          <span className="text-sm font-medium">Freshness</span>
+          <select name="freshness" value={filters.freshness ?? ''} onChange={handleSelectChange}>
             <option value="">Any</option>
             <option value="7">7 days</option>
             <option value="30">30 days</option>
             <option value="90">90 days</option>
           </select>
         </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-sm font-medium">Sort</span>
+          <select name="sort" value={filters.sort ?? ''} onChange={handleSelectChange}>
+            {SORT_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
       </div>
-      <div>
-        <label>
+      <div className="space-y-2">
+        <label className="flex items-center gap-2">
           <input
             type="checkbox"
             name="nearTransit"
             checked={filters.nearTransit ?? false}
             onChange={handleCheckboxChange}
           />
-          Near Transit
+          <span className="text-sm font-medium">Near Transit (BTS/MRT)</span>
         </label>
         {Object.keys(transitLines).length > 0 && (
-          <>
-            <label>
-              Line
+          <div className="grid gap-2 md:grid-cols-2">
+            <label className="flex flex-col gap-1">
+              <span className="text-sm font-medium">Transit Line</span>
               <select
                 name="transitLine"
                 value={filters.transitLine ?? ''}
@@ -191,64 +505,42 @@ export default function PropertyFilters({ filters, onChange }: Props) {
                 ))}
               </select>
             </label>
-            {filters.transitLine && (
-              <label>
-                Station
-                <select
-                  name="transitStation"
-                  value={filters.transitStation ?? ''}
-                  onChange={handleSelectChange}
-                >
-                  <option value="">Any</option>
-                  {transitLines[filters.transitLine].map((st) => (
-                    <option key={st} value={st}>
-                      {st}
+            <label className="flex flex-col gap-1">
+              <span className="text-sm font-medium">Transit Station</span>
+              <select
+                name="transitStation"
+                value={filters.transitStation ?? ''}
+                onChange={handleSelectChange}
+                disabled={!filters.transitLine}
+              >
+                <option value="">Any</option>
+                {filters.transitLine &&
+                  (transitLines[filters.transitLine] || []).map((station) => (
+                    <option key={station} value={station}>
+                      {station}
                     </option>
                   ))}
-                </select>
-              </label>
-            )}
-          </>
+              </select>
+            </label>
+          </div>
         )}
-        <label>
-          Furnished
-          <select
-            name="furnished"
-            value={filters.furnished ?? ''}
-            onChange={handleSelectChange}
-          >
-            <option value="">Any</option>
-            <option value="furnished">Furnished</option>
-            <option value="unfurnished">Unfurnished</option>
-          </select>
-        </label>
       </div>
-      <div>
-        <label>
-          Sort
-          <select name="sort" value={filters.sort ?? ''} onChange={handleSelectChange}>
-            <option value="">Default</option>
-            <option value="price-asc">Price Low-High</option>
-            <option value="price-desc">Price High-Low</option>
-            <option value="created-desc">Newest</option>
-            <option value="created-asc">Oldest</option>
-          </select>
-        </label>
-      </div>
-      <div>
-        Amenities:
-        {amenitiesList.map((a) => (
-          <label key={a}>
-            <input
-              type="checkbox"
-              name="amenities"
-              value={a}
-              checked={filters.amenities?.includes(a) ?? false}
-              onChange={handleCheckboxChange}
-            />
-            {a}
-          </label>
-        ))}
+      <div className="space-y-2">
+        <span className="text-sm font-medium">Amenities / Tags</span>
+        <div className="flex flex-wrap gap-2">
+          {amenitiesList.map((a) => (
+            <label key={a} className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                name="amenities"
+                value={a}
+                checked={filters.amenities?.includes(a) ?? false}
+                onChange={handleCheckboxChange}
+              />
+              {titleCase(a)}
+            </label>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/src/lib/search/shared.ts
+++ b/src/lib/search/shared.ts
@@ -1,25 +1,100 @@
 import type { SearchParams } from '../validation/search';
 
+const STATUS_ORDER: Record<string, number> = {
+  AVAILABLE: 0,
+  RESERVED: 1,
+  SOLD: 2,
+};
+
+const normalize = (value?: string) => value?.toString().trim().toLowerCase();
+
+function statusRank(status?: string) {
+  const normalized = status?.toString().trim().toUpperCase();
+  if (!normalized) return STATUS_ORDER.AVAILABLE ?? 0;
+  return STATUS_ORDER[normalized] ?? STATUS_ORDER.SOLD ?? 2;
+}
+
+function compareStatus(a: any, b: any) {
+  return statusRank(a.status) - statusRank(b.status);
+}
+
+function compareDateDesc(a: any, b: any, key: 'updatedAt' | 'createdAt') {
+  const aTime = a?.[key] ? new Date(a[key]).getTime() : 0;
+  const bTime = b?.[key] ? new Date(b[key]).getTime() : 0;
+  return bTime - aTime;
+}
+
 export function applyFilters(docs: any[], req: SearchParams) {
   return docs.filter((doc) => {
-    if (req.province && doc.province !== req.province && doc.province_th !== req.province) return false;
-    if (req.type && doc.type !== req.type) return false;
+    if (req.province) {
+      const province = normalize(req.province);
+      if (
+        normalize(doc.province) !== province &&
+        normalize(doc.province_th) !== province
+      ) {
+        return false;
+      }
+    }
+    if (req.district) {
+      const district = normalize(req.district);
+      if (
+        normalize(doc.district) !== district &&
+        normalize(doc.district_th) !== district
+      ) {
+        return false;
+      }
+    }
+    if (req.type) {
+      if (normalize(doc.type) !== normalize(req.type)) return false;
+    }
     if (req.minPrice !== undefined && doc.price < req.minPrice) return false;
     if (req.maxPrice !== undefined && doc.price > req.maxPrice) return false;
-    if (req.beds !== undefined && (doc.beds ?? 0) < req.beds) return false;
-    if (req.baths !== undefined && (doc.baths ?? 0) < req.baths) return false;
-    if (req.status && doc.status !== req.status) return false;
+    const beds = doc.beds ?? 0;
+    if (req.beds !== undefined && beds < req.beds) return false;
+    if (req.bedsMin !== undefined && beds < req.bedsMin) return false;
+    if (req.bedsMax !== undefined && beds > req.bedsMax) return false;
+    const baths = doc.baths ?? 0;
+    if (req.baths !== undefined && baths < req.baths) return false;
+    if (req.bathsMin !== undefined && baths < req.bathsMin) return false;
+    if (req.bathsMax !== undefined && baths > req.bathsMax) return false;
+    const area = doc.area ?? doc.areaBuilt;
+    if (req.minArea !== undefined) {
+      if (area === undefined || area < req.minArea) return false;
+    }
+    if (req.maxArea !== undefined) {
+      if (area === undefined || area > req.maxArea) return false;
+    }
+    if (req.status) {
+      if (normalize(doc.status) !== normalize(req.status)) return false;
+    }
     if (req.freshness !== undefined) {
-      const days = (Date.now() - new Date(doc.createdAt).getTime()) / (1000 * 60 * 60 * 24);
+      const sourceDate = doc.updatedAt ?? doc.createdAt;
+      const base = sourceDate ? new Date(sourceDate).getTime() : 0;
+      const days = base ? (Date.now() - base) / (1000 * 60 * 60 * 24) : Infinity;
       if (days > req.freshness) return false;
     }
     if (req.nearTransit && !doc.nearTransit) return false;
-    if (req.transitLine && doc.transitLine !== req.transitLine) return false;
-    if (req.transitStation && doc.transitStation !== req.transitStation) return false;
-    if (req.furnished && doc.furnished !== req.furnished) return false;
+    if (req.transitLine && normalize(doc.transitLine) !== normalize(req.transitLine)) return false;
+    if (
+      req.transitStation &&
+      normalize(doc.transitStation) !== normalize(req.transitStation)
+    )
+      return false;
+    if (req.furnished && normalize(doc.furnished) !== normalize(req.furnished)) return false;
     if (req.amenities && req.amenities.length) {
+      const amenities: string[] = Array.isArray(doc.amenities) ? doc.amenities : [];
       for (const a of req.amenities) {
-        if (!doc.amenities.includes(a)) return false;
+        if (!amenities.some((value) => normalize(value) === normalize(a))) {
+          return false;
+        }
+      }
+    }
+    if (req.tags && req.tags.length) {
+      const tags: string[] = Array.isArray(doc.tags) ? doc.tags : [];
+      for (const tag of req.tags) {
+        if (!tags.some((value) => normalize(value) === normalize(tag))) {
+          return false;
+        }
       }
     }
     return true;
@@ -27,15 +102,52 @@ export function applyFilters(docs: any[], req: SearchParams) {
 }
 
 export function sortResults(docs: any[], sort: SearchParams['sort']) {
+  const byStatus = (a: any, b: any) => {
+    const statusCompare = compareStatus(a, b);
+    if (statusCompare !== 0) return statusCompare;
+    const updatedCompare = compareDateDesc(a, b, 'updatedAt');
+    if (updatedCompare !== 0) return updatedCompare;
+    return compareDateDesc(a, b, 'createdAt');
+  };
+
   switch (sort) {
     case 'price-asc':
-      return docs.sort((a, b) => a.price - b.price);
+      return docs.sort((a, b) => {
+        const priceDiff = (a.price ?? 0) - (b.price ?? 0);
+        if (priceDiff !== 0) return priceDiff;
+        return byStatus(a, b);
+      });
     case 'price-desc':
-      return docs.sort((a, b) => b.price - a.price);
+      return docs.sort((a, b) => {
+        const priceDiff = (b.price ?? 0) - (a.price ?? 0);
+        if (priceDiff !== 0) return priceDiff;
+        return byStatus(a, b);
+      });
+    case 'views-desc':
+      return docs.sort((a, b) => {
+        const viewsDiff = (b.views ?? 0) - (a.views ?? 0);
+        if (viewsDiff !== 0) return viewsDiff;
+        return byStatus(a, b);
+      });
+    case 'updated-desc':
+      return docs.sort((a, b) => {
+        const updatedCompare = compareDateDesc(a, b, 'updatedAt');
+        if (updatedCompare !== 0) return updatedCompare;
+        return byStatus(a, b);
+      });
     case 'created-asc':
-      return docs.sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+      return docs.sort((a, b) => {
+        const createdCompare = compareDateDesc(b, a, 'createdAt');
+        if (createdCompare !== 0) return createdCompare;
+        return byStatus(a, b);
+      });
     case 'created-desc':
+      return docs.sort((a, b) => {
+        const createdCompare = compareDateDesc(a, b, 'createdAt');
+        if (createdCompare !== 0) return createdCompare;
+        return byStatus(a, b);
+      });
     default:
-      return docs.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+      return docs.sort(byStatus);
   }
 }

--- a/src/lib/validation/search.ts
+++ b/src/lib/validation/search.ts
@@ -1,11 +1,16 @@
 import { z } from 'zod';
 import { MIN_PRICE, MAX_PRICE, isValidPrice } from '../filters/price';
 
-const safeString = z.string().trim().regex(/^[\p{L}\p{N}\s-]+$/u);
+const safeString = z
+  .string()
+  .trim()
+  .regex(/^[\p{L}\p{N}\s_\-\/&()]+$/u);
 
-export const searchParamsSchema = z.object({
+export const searchParamsSchema = z
+  .object({
   query: safeString.optional(),
   province: safeString.optional(),
+  district: safeString.optional(),
   type: safeString.optional(),
   locale: z.enum(['en', 'th', 'zh']).optional(),
   minPrice: z
@@ -26,12 +31,24 @@ export const searchParamsSchema = z.object({
     .optional(),
   beds: z.coerce.number().int().nonnegative().optional(),
   baths: z.coerce.number().int().nonnegative().optional(),
-  status: z.enum(['sale', 'rent']).optional(),
+  bedsMin: z.coerce.number().int().nonnegative().optional(),
+  bedsMax: z.coerce.number().int().nonnegative().optional(),
+  bathsMin: z.coerce.number().int().nonnegative().optional(),
+  bathsMax: z.coerce.number().int().nonnegative().optional(),
+  minArea: z.coerce.number().int().nonnegative().optional(),
+  maxArea: z.coerce.number().int().nonnegative().optional(),
+  status: safeString.optional(),
   freshness: z.coerce.number().int().nonnegative().optional(),
   nearTransit: z.coerce.boolean().optional(),
-  furnished: z.enum(['furnished', 'unfurnished']).optional(),
-  sort: z.enum(['price-asc', 'price-desc', 'created-asc', 'created-desc']).optional(),
+  furnished: safeString.optional(),
+  sort: z
+    .enum(['price-asc', 'price-desc', 'views-desc', 'updated-desc', 'created-asc', 'created-desc'])
+    .optional(),
   amenities: z
+    .union([safeString, z.array(safeString)])
+    .transform((val) => (Array.isArray(val) ? val : [val]))
+    .optional(),
+  tags: z
     .union([safeString, z.array(safeString)])
     .transform((val) => (Array.isArray(val) ? val : [val]))
     .optional(),
@@ -39,30 +56,52 @@ export const searchParamsSchema = z.object({
   transitStation: safeString.optional(),
   page: z.coerce.number().int().positive().optional(),
   pageSize: z.coerce.number().int().positive().max(100).optional(),
-}).refine(
-  (data) =>
-    data.minPrice === undefined ||
-    data.maxPrice === undefined ||
-    data.minPrice <= data.maxPrice,
-  {
-    message: 'minPrice cannot exceed maxPrice',
-    path: ['maxPrice'],
-  }
-);
+  })
+  .superRefine((data, ctx) => {
+    const addRangeIssue = (
+      minKey: 'minPrice' | 'bedsMin' | 'bathsMin' | 'minArea',
+      maxKey: 'maxPrice' | 'bedsMax' | 'bathsMax' | 'maxArea',
+      message: string
+    ) => {
+      const min = data[minKey] as number | undefined;
+      const max = data[maxKey] as number | undefined;
+      if (min !== undefined && max !== undefined && min > max) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [maxKey],
+          message,
+        });
+      }
+    };
+
+    addRangeIssue('minPrice', 'maxPrice', 'minPrice cannot exceed maxPrice');
+    addRangeIssue('bedsMin', 'bedsMax', 'bedsMin cannot exceed bedsMax');
+    addRangeIssue('bathsMin', 'bathsMax', 'bathsMin cannot exceed bathsMax');
+    addRangeIssue('minArea', 'maxArea', 'minArea cannot exceed maxArea');
+  });
 
 export type SearchParams = z.infer<typeof searchParamsSchema>;
-
 export const filterParamsSchema = searchParamsSchema.pick({
+  province: true,
+  district: true,
+  type: true,
   minPrice: true,
   maxPrice: true,
   beds: true,
   baths: true,
+  bedsMin: true,
+  bedsMax: true,
+  bathsMin: true,
+  bathsMax: true,
+  minArea: true,
+  maxArea: true,
   status: true,
   freshness: true,
   nearTransit: true,
   furnished: true,
   sort: true,
   amenities: true,
+  tags: true,
   transitLine: true,
   transitStation: true,
 });


### PR DESCRIPTION
## Summary
- expand the property filters UI to cover province/district, property type, range inputs, area, furnishings, transit, and amenity selections backed by `/data` manifests
- extend search parameter validation and filtering/sorting logic to handle the new fields while defaulting results by availability status and supporting price/views/updated ordering
- enrich the search worker payload with district, updatedAt, and views metadata and update property cards to surface status badges and currency-aware pricing

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: existing project type errors for prisma typings, minisearch declarations, and DOM keyboard event types)*


------
https://chatgpt.com/codex/tasks/task_e_68cc56d4e050832bbea5f1e3c696d3bd