### PR TITLE
Add localized console hub with authentication guard

### DIFF
--- a/components/Header/NavBar.tsx
+++ b/components/Header/NavBar.tsx
@@ -76,6 +76,13 @@ export default function NavBar() {
             <li><CurrencySwitcher /></li>
           </ul>
           <ContactIcons className="hidden xl:flex" />
+          <Link
+            href={`/${activeLocale}/console`}
+            className="ml-2 inline-flex h-10 w-10 items-center justify-center rounded-full border border-neutral-300 text-lg"
+            aria-label="Open console hub"
+          >
+            <span aria-hidden="true">👤</span>
+          </Link>
           <button
             type="button"
             ref={searchToggleRef}

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -14,5 +14,71 @@
   "Brand": {
     "name": "Zomzom Property",
     "tagline": "Multilingual real estate partner."
+  },
+  "Console": {
+    "heading": "Your console",
+    "greeting": "Welcome back, {{name}}",
+    "nav": {
+      "ariaLabel": "Console navigation",
+      "overview": "Overview",
+      "account": "Account",
+      "posts": "Posts",
+      "favorites": "Favorites"
+    },
+    "plans": {
+      "free": "Free",
+      "premium": "Premium"
+    },
+    "overview": {
+      "plan": "Subscription",
+      "planHelper": "Manage your plan from the account tab.",
+      "posts": "Listings",
+      "favorites": "Favorites",
+      "favoritesLimit": "You have reached your favorites limit.",
+      "favoritesRemaining": "{{count}} favorites remaining",
+      "activityTitle": "Recent activity",
+      "activityDescription": "Track your saved homes and listings performance at a glance."
+    },
+    "paywall": {
+      "title": "Unlock more publishing power",
+      "description": "Upgrade to Premium to publish unlimited listings and access enhanced promotion tools.",
+      "upgradeCta": "Upgrade",
+      "contactCta": "Contact sales"
+    },
+    "account": {
+      "title": "Account details",
+      "name": "Name",
+      "email": "Email",
+      "plan": "Plan",
+      "localeTitle": "Preferred language",
+      "localeDescription": "Choose the language used across your console experience."
+    },
+    "locales": {
+      "th": "Thai",
+      "en": "English",
+      "zh": "Chinese"
+    },
+    "posts": {
+      "title": "Your listings",
+      "createCta": "Create listing",
+      "paywallHint": "Upgrade to continue publishing more than three listings on the free plan.",
+      "emptyState": "You have not published any listings yet.",
+      "manageCta": "Manage",
+      "placeholderTitle": "Listing draft {{index}}",
+      "status": {
+        "published": "Published",
+        "draft": "Draft"
+      }
+    },
+    "favorites": {
+      "title": "Saved homes",
+      "limitReached": "Favorites limit reached ({{count}})",
+      "remaining": "{{count}} favorites remaining",
+      "counter": "{{used}} of {{limit}}",
+      "emptyState": "You have not saved any homes yet.",
+      "placeholderTitle": "Dream home {{index}}",
+      "placeholderLocation": "Bangkok, Thailand",
+      "viewCta": "View"
+    }
   }
 }

--- a/locales/th/common.json
+++ b/locales/th/common.json
@@ -14,5 +14,71 @@
   "Brand": {
     "name": "Zomzom Property",
     "tagline": "พันธมิตรอสังหาริมทรัพย์หลายภาษา"
+  },
+  "Console": {
+    "heading": "คอนโซลของคุณ",
+    "greeting": "ยินดีต้อนรับกลับ {{name}}",
+    "nav": {
+      "ariaLabel": "เมนูคอนโซล",
+      "overview": "ภาพรวม",
+      "account": "บัญชี",
+      "posts": "ประกาศ",
+      "favorites": "รายการโปรด"
+    },
+    "plans": {
+      "free": "ฟรี",
+      "premium": "พรีเมียม"
+    },
+    "overview": {
+      "plan": "การสมัครสมาชิก",
+      "planHelper": "จัดการแพ็กเกจของคุณได้ที่แท็บบัญชี",
+      "posts": "ประกาศ",
+      "favorites": "รายการโปรด",
+      "favoritesLimit": "คุณใช้โควต้ารายการโปรดครบแล้ว",
+      "favoritesRemaining": "เหลืออีก {{count}} รายการ",
+      "activityTitle": "กิจกรรมล่าสุด",
+      "activityDescription": "ติดตามรายการโปรดและประสิทธิภาพประกาศของคุณได้อย่างรวดเร็ว"
+    },
+    "paywall": {
+      "title": "ปลดล็อกการลงประกาศมากขึ้น",
+      "description": "อัปเกรดเป็นพรีเมียมเพื่อโพสต์ได้ไม่จำกัดและใช้เครื่องมือโปรโมตขั้นสูง",
+      "upgradeCta": "อัปเกรด",
+      "contactCta": "ติดต่อฝ่ายขาย"
+    },
+    "account": {
+      "title": "ข้อมูลบัญชี",
+      "name": "ชื่อ",
+      "email": "อีเมล",
+      "plan": "แพ็กเกจ",
+      "localeTitle": "ภาษาที่ต้องการ",
+      "localeDescription": "เลือกภาษาสำหรับการใช้งานคอนโซล"
+    },
+    "locales": {
+      "th": "ไทย",
+      "en": "อังกฤษ",
+      "zh": "จีน"
+    },
+    "posts": {
+      "title": "ประกาศของคุณ",
+      "createCta": "สร้างประกาศ",
+      "paywallHint": "อัปเกรดเพื่อโพสต์เกินสามประกาศในแพ็กเกจฟรี",
+      "emptyState": "ยังไม่มีประกาศ",
+      "manageCta": "จัดการ",
+      "placeholderTitle": "ประกาศร่าง {{index}}",
+      "status": {
+        "published": "เผยแพร่",
+        "draft": "ร่าง"
+      }
+    },
+    "favorites": {
+      "title": "บ้านที่บันทึกไว้",
+      "limitReached": "ใช้โควต้ารายการโปรดครบ ({{count}})",
+      "remaining": "เหลืออีก {{count}} รายการ",
+      "counter": "{{used}} จาก {{limit}}",
+      "emptyState": "ยังไม่มีบ้านที่บันทึก",
+      "placeholderTitle": "บ้านในฝัน {{index}}",
+      "placeholderLocation": "กรุงเทพฯ ประเทศไทย",
+      "viewCta": "ดูรายละเอียด"
+    }
   }
 }

--- a/locales/zh/common.json
+++ b/locales/zh/common.json
@@ -14,5 +14,71 @@
   "Brand": {
     "name": "Zomzom Property",
     "tagline": "多语言房地产合作伙伴"
+  },
+  "Console": {
+    "heading": "控制台",
+    "greeting": "欢迎回来，{{name}}",
+    "nav": {
+      "ariaLabel": "控制台导航",
+      "overview": "概览",
+      "account": "账户",
+      "posts": "房源",
+      "favorites": "收藏"
+    },
+    "plans": {
+      "free": "免费",
+      "premium": "尊享"
+    },
+    "overview": {
+      "plan": "订阅",
+      "planHelper": "前往账户标签管理套餐。",
+      "posts": "房源",
+      "favorites": "收藏",
+      "favoritesLimit": "您的收藏已达上限。",
+      "favoritesRemaining": "剩余 {{count}} 个收藏名额",
+      "activityTitle": "最新动态",
+      "activityDescription": "快速查看收藏与房源表现。"
+    },
+    "paywall": {
+      "title": "解锁更多发布次数",
+      "description": "升级至尊享套餐即可无限发布并获得高级推广工具。",
+      "upgradeCta": "立即升级",
+      "contactCta": "联系销售"
+    },
+    "account": {
+      "title": "账户信息",
+      "name": "姓名",
+      "email": "邮箱",
+      "plan": "套餐",
+      "localeTitle": "首选语言",
+      "localeDescription": "选择控制台显示语言。"
+    },
+    "locales": {
+      "th": "泰语",
+      "en": "英语",
+      "zh": "中文"
+    },
+    "posts": {
+      "title": "我的房源",
+      "createCta": "创建房源",
+      "paywallHint": "免费套餐最多发布三条房源，更多请升级。",
+      "emptyState": "暂未发布任何房源。",
+      "manageCta": "管理",
+      "placeholderTitle": "房源草稿 {{index}}",
+      "status": {
+        "published": "已发布",
+        "draft": "草稿"
+      }
+    },
+    "favorites": {
+      "title": "收藏房源",
+      "limitReached": "收藏上限 ({{count}})",
+      "remaining": "剩余 {{count}} 个收藏名额",
+      "counter": "{{used}} / {{limit}}",
+      "emptyState": "您还没有收藏任何房源。",
+      "placeholderTitle": "心仪房源 {{index}}",
+      "placeholderLocation": "泰国 曼谷",
+      "viewCta": "查看"
+    }
   }
 }

--- a/pages/[locale]/console/account.tsx
+++ b/pages/[locale]/console/account.tsx
@@ -1,0 +1,18 @@
+import { NextSeo } from 'next-seo'
+import ConsoleAccountView, {
+  getServerSideProps,
+} from '@/views/console/ConsoleAccountView'
+import type { InferGetServerSidePropsType } from 'next'
+
+export { getServerSideProps } from '@/views/console/ConsoleAccountView'
+
+type Props = InferGetServerSidePropsType<typeof getServerSideProps>
+
+export default function ConsoleAccountPage(props: Props) {
+  return (
+    <>
+      <NextSeo {...props.head.seo} />
+      <ConsoleAccountView {...props} />
+    </>
+  )
+}

--- a/pages/[locale]/console/favorites.tsx
+++ b/pages/[locale]/console/favorites.tsx
@@ -1,0 +1,18 @@
+import { NextSeo } from 'next-seo'
+import ConsoleFavoritesView, {
+  getServerSideProps,
+} from '@/views/console/ConsoleFavoritesView'
+import type { InferGetServerSidePropsType } from 'next'
+
+export { getServerSideProps } from '@/views/console/ConsoleFavoritesView'
+
+type Props = InferGetServerSidePropsType<typeof getServerSideProps>
+
+export default function ConsoleFavoritesPage(props: Props) {
+  return (
+    <>
+      <NextSeo {...props.head.seo} />
+      <ConsoleFavoritesView {...props} />
+    </>
+  )
+}

--- a/pages/[locale]/console/index.tsx
+++ b/pages/[locale]/console/index.tsx
@@ -1,0 +1,18 @@
+import { NextSeo } from 'next-seo'
+import ConsoleOverviewView, {
+  getServerSideProps,
+} from '@/views/console/ConsoleOverviewView'
+import type { InferGetServerSidePropsType } from 'next'
+
+export { getServerSideProps } from '@/views/console/ConsoleOverviewView'
+
+type Props = InferGetServerSidePropsType<typeof getServerSideProps>
+
+export default function ConsoleOverviewPage(props: Props) {
+  return (
+    <>
+      <NextSeo {...props.head.seo} />
+      <ConsoleOverviewView {...props} />
+    </>
+  )
+}

--- a/pages/[locale]/console/posts.tsx
+++ b/pages/[locale]/console/posts.tsx
@@ -1,0 +1,18 @@
+import { NextSeo } from 'next-seo'
+import ConsolePostsView, {
+  getServerSideProps,
+} from '@/views/console/ConsolePostsView'
+import type { InferGetServerSidePropsType } from 'next'
+
+export { getServerSideProps } from '@/views/console/ConsolePostsView'
+
+type Props = InferGetServerSidePropsType<typeof getServerSideProps>
+
+export default function ConsolePostsPage(props: Props) {
+  return (
+    <>
+      <NextSeo {...props.head.seo} />
+      <ConsolePostsView {...props} />
+    </>
+  )
+}

--- a/src/context/ConsoleUserContext.tsx
+++ b/src/context/ConsoleUserContext.tsx
@@ -1,0 +1,71 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react'
+import { CONSOLE_LOCALE_COOKIE, type ConsoleUserSession } from '@/lib/auth/consoleSession'
+
+export type SubscriptionPlan = ConsoleUserSession['plan']
+
+export interface ConsoleUser extends ConsoleUserSession {}
+
+interface ConsoleUserContextValue {
+  user: ConsoleUser
+  updateLocalePreference: (locale: string) => void
+}
+
+const ConsoleUserContext = createContext<ConsoleUserContextValue | undefined>(
+  undefined,
+)
+
+function persistLocalePreference(locale: string) {
+  if (typeof document === 'undefined') return
+
+  const oneYear = 365 * 24 * 60 * 60 * 1000
+  const expires = new Date(Date.now() + oneYear).toUTCString()
+  document.cookie = `${CONSOLE_LOCALE_COOKIE}=${encodeURIComponent(
+    locale,
+  )}; Path=/; Expires=${expires}`
+}
+
+interface ConsoleUserProviderProps {
+  initialUser: ConsoleUser
+  children: ReactNode
+}
+
+export function ConsoleUserProvider({
+  initialUser,
+  children,
+}: ConsoleUserProviderProps) {
+  const [user, setUser] = useState<ConsoleUser>(initialUser)
+
+  const updateLocalePreference = useCallback((locale: string) => {
+    setUser((current) => ({ ...current, localePreference: locale }))
+    persistLocalePreference(locale)
+  }, [])
+
+  const value = useMemo(
+    () => ({
+      user,
+      updateLocalePreference,
+    }),
+    [user, updateLocalePreference],
+  )
+
+  return (
+    <ConsoleUserContext.Provider value={value}>
+      {children}
+    </ConsoleUserContext.Provider>
+  )
+}
+
+export function useConsoleUser(): ConsoleUserContextValue {
+  const context = useContext(ConsoleUserContext)
+  if (!context) {
+    throw new Error('useConsoleUser must be used within a ConsoleUserProvider')
+  }
+  return context
+}

--- a/src/hooks/useConsolePaywall.ts
+++ b/src/hooks/useConsolePaywall.ts
@@ -1,0 +1,43 @@
+import { useMemo } from 'react'
+import { useConsoleUser } from '@/context/ConsoleUserContext'
+
+const POST_LIMIT: Record<'free' | 'premium', number> = {
+  free: 3,
+  premium: 100,
+}
+
+export interface ConsolePaywallState {
+  plan: 'free' | 'premium'
+  used: number
+  limit: number
+  remaining: number
+  showPaywall: boolean
+  message: string
+  cta: string
+}
+
+export function useConsolePaywall(): ConsolePaywallState {
+  const { user } = useConsoleUser()
+
+  return useMemo(() => {
+    const limit = POST_LIMIT[user.plan]
+    const used = Math.max(0, user.postsUsed)
+    const remaining = Math.max(limit - used, 0)
+    const showPaywall = user.plan === 'free' && remaining === 0
+    const message = showPaywall
+      ? `Upgrade to Premium to publish more than ${limit} listings.`
+      : `You can publish ${remaining} more ${remaining === 1 ? 'listing' : 'listings'}.`
+
+    const cta = showPaywall ? 'Upgrade now' : 'Create listing'
+
+    return {
+      plan: user.plan,
+      used,
+      limit,
+      remaining,
+      showPaywall,
+      message,
+      cta,
+    }
+  }, [user])
+}

--- a/src/hooks/useFavoritesQuota.ts
+++ b/src/hooks/useFavoritesQuota.ts
@@ -1,0 +1,32 @@
+import { useMemo } from 'react'
+import { useConsoleUser } from '@/context/ConsoleUserContext'
+
+const FAVORITES_LIMIT: Record<'free' | 'premium', number> = {
+  free: 20,
+  premium: 100,
+}
+
+export interface FavoritesQuotaState {
+  plan: 'free' | 'premium'
+  used: number
+  limit: number
+  remaining: number
+  isAtLimit: boolean
+}
+
+export function useFavoritesQuota(): FavoritesQuotaState {
+  const { user } = useConsoleUser()
+
+  return useMemo(() => {
+    const limit = FAVORITES_LIMIT[user.plan]
+    const used = Math.max(0, user.favoritesUsed)
+    const remaining = Math.max(limit - used, 0)
+    return {
+      plan: user.plan,
+      used,
+      limit,
+      remaining,
+      isAtLimit: remaining === 0,
+    }
+  }, [user])
+}

--- a/src/lib/auth/consoleSession.ts
+++ b/src/lib/auth/consoleSession.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod'
+import type { CookieMap } from '@/lib/http/cookies'
+
+export const CONSOLE_USER_COOKIE = 'console_user'
+export const CONSOLE_LOCALE_COOKIE = 'console_locale'
+
+const consoleUserSchema = z
+  .object({
+    id: z.string().min(1),
+    name: z.string().min(1),
+    email: z.string().email(),
+    plan: z.union([z.literal('free'), z.literal('premium')]),
+    favoritesUsed: z.number().int().min(0).default(0),
+    postsUsed: z.number().int().min(0).default(0),
+    localePreference: z.string().min(2).max(5).optional(),
+  })
+  .transform((data) => ({
+    ...data,
+    favoritesUsed: data.favoritesUsed ?? 0,
+    postsUsed: data.postsUsed ?? 0,
+  }))
+
+export type ConsoleUserSession = z.infer<typeof consoleUserSchema>
+
+function decodeBase64Json(value: string): unknown {
+  const json = Buffer.from(value, 'base64url').toString('utf8')
+  return JSON.parse(json)
+}
+
+export function parseConsoleUser(value: string | undefined): ConsoleUserSession | null {
+  if (!value) return null
+
+  try {
+    const raw = decodeBase64Json(value)
+    return consoleUserSchema.parse(raw)
+  } catch {
+    return null
+  }
+}
+
+export function getConsoleUserFromCookies(
+  cookies: CookieMap,
+): ConsoleUserSession | null {
+  const raw = cookies[CONSOLE_USER_COOKIE]
+  return parseConsoleUser(raw)
+}

--- a/src/views/console/ConsoleAccountView.tsx
+++ b/src/views/console/ConsoleAccountView.tsx
@@ -1,0 +1,101 @@
+import { useCallback, type ChangeEvent } from 'react'
+import { useRouter } from 'next/router'
+import { useTranslation } from 'next-i18next'
+import ConsoleLayout from './ConsoleLayout'
+import type { ConsolePageBaseProps } from './types'
+import { createConsoleGetServerSideProps } from './consoleServer'
+import { ConsoleUserProvider, useConsoleUser } from '@/context/ConsoleUserContext'
+
+interface ConsoleAccountViewProps extends ConsolePageBaseProps {}
+
+function ConsoleAccountContent(props: ConsoleAccountViewProps) {
+  const router = useRouter()
+  const { t } = useTranslation('common')
+  const { user, updateLocalePreference } = useConsoleUser()
+
+  const handleLocaleChange = useCallback(
+    (event: ChangeEvent<HTMLSelectElement>) => {
+      const nextLocale = event.target.value
+      updateLocalePreference(nextLocale)
+      if (nextLocale !== router.locale) {
+        const pathSuffix = router.asPath.replace(/^\/[^/]+/, '')
+        router.push(`/${nextLocale}${pathSuffix}`)
+      }
+    },
+    [router, updateLocalePreference],
+  )
+
+  return (
+    <ConsoleLayout {...props} activeTab="account">
+      <section className="rounded-lg border border-neutral-200 bg-white p-6 shadow-sm space-y-4">
+        <h2 className="text-lg font-semibold text-neutral-900">
+          {t('Console.account.title')}
+        </h2>
+        <div className="space-y-3">
+          <div>
+            <p className="text-xs uppercase tracking-wide text-neutral-400">
+              {t('Console.account.name')}
+            </p>
+            <p className="mt-1 text-sm font-medium text-neutral-800">{user.name}</p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-wide text-neutral-400">
+              {t('Console.account.email')}
+            </p>
+            <p className="mt-1 text-sm font-medium text-neutral-800">{user.email}</p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-wide text-neutral-400">
+              {t('Console.account.plan')}
+            </p>
+            <p className="mt-1 text-sm font-medium text-neutral-800">
+              {t(`Console.plans.${user.plan}`)}
+            </p>
+          </div>
+        </div>
+      </section>
+      <section className="rounded-lg border border-neutral-200 bg-white p-6 shadow-sm space-y-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <h3 className="text-lg font-semibold text-neutral-900">
+              {t('Console.account.localeTitle')}
+            </h3>
+            <p className="text-sm text-neutral-500">
+              {t('Console.account.localeDescription')}
+            </p>
+          </div>
+          <div>
+            <label className="sr-only" htmlFor="console-locale">
+              {t('Console.account.localeTitle')}
+            </label>
+            <select
+              id="console-locale"
+              value={user.localePreference ?? router.locale}
+              onChange={handleLocaleChange}
+              className="rounded-md border border-neutral-300 bg-white px-3 py-2 text-sm"
+            >
+              {(router.locales ?? []).map((code) => (
+                <option key={code} value={code}>
+                  {t(`Console.locales.${code}`, code)}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+      </section>
+    </ConsoleLayout>
+  )
+}
+
+export default function ConsoleAccountView(props: ConsoleAccountViewProps) {
+  return (
+    <ConsoleUserProvider initialUser={props.user}>
+      <ConsoleAccountContent {...props} />
+    </ConsoleUserProvider>
+  )
+}
+
+export const getServerSideProps = createConsoleGetServerSideProps({
+  seoPath: '/console/account',
+  seoTitle: 'Console Account',
+})

--- a/src/views/console/ConsoleFavoritesView.tsx
+++ b/src/views/console/ConsoleFavoritesView.tsx
@@ -1,0 +1,83 @@
+import { useMemo } from 'react'
+import { useTranslation } from 'next-i18next'
+import ConsoleLayout from './ConsoleLayout'
+import type { ConsolePageBaseProps } from './types'
+import { createConsoleGetServerSideProps } from './consoleServer'
+import { useFavoritesQuota } from '@/hooks/useFavoritesQuota'
+import { ConsoleUserProvider } from '@/context/ConsoleUserContext'
+
+interface ConsoleFavoritesViewProps extends ConsolePageBaseProps {}
+
+function ConsoleFavoritesContent(props: ConsoleFavoritesViewProps) {
+  const { user } = props
+  const { t } = useTranslation('common')
+  const favorites = useFavoritesQuota()
+
+  const items = useMemo(
+    () =>
+      Array.from({ length: user.favoritesUsed }, (_, index) => ({
+        id: `${index + 1}`,
+        title: t('Console.favorites.placeholderTitle', { index: index + 1 }),
+        location: t('Console.favorites.placeholderLocation'),
+      })),
+    [t, user.favoritesUsed],
+  )
+
+  return (
+    <ConsoleLayout {...props} activeTab="favorites">
+      <section className="rounded-lg border border-neutral-200 bg-white p-6 shadow-sm space-y-4">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <h2 className="text-lg font-semibold text-neutral-900">
+              {t('Console.favorites.title')}
+            </h2>
+            <p className="text-sm text-neutral-500">
+              {favorites.isAtLimit
+                ? t('Console.favorites.limitReached', { count: favorites.limit })
+                : t('Console.favorites.remaining', { count: favorites.remaining })}
+            </p>
+          </div>
+          <span className="rounded-full bg-neutral-100 px-3 py-1 text-xs font-semibold text-neutral-600">
+            {t('Console.favorites.counter', {
+              used: favorites.used,
+              limit: favorites.limit,
+            })}
+          </span>
+        </div>
+        <ul className="divide-y divide-neutral-200">
+          {items.length === 0 && (
+            <li className="py-6 text-sm text-neutral-500">
+              {t('Console.favorites.emptyState')}
+            </li>
+          )}
+          {items.map((item) => (
+            <li key={item.id} className="py-4">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <p className="text-sm font-semibold text-neutral-900">{item.title}</p>
+                  <p className="text-xs text-neutral-500">{item.location}</p>
+                </div>
+                <button className="text-sm font-semibold text-emerald-600 hover:text-emerald-700">
+                  {t('Console.favorites.viewCta')}
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </ConsoleLayout>
+  )
+}
+
+export default function ConsoleFavoritesView(props: ConsoleFavoritesViewProps) {
+  return (
+    <ConsoleUserProvider initialUser={props.user}>
+      <ConsoleFavoritesContent {...props} />
+    </ConsoleUserProvider>
+  )
+}
+
+export const getServerSideProps = createConsoleGetServerSideProps({
+  seoPath: '/console/favorites',
+  seoTitle: 'Console Favorites',
+})

--- a/src/views/console/ConsoleLayout.tsx
+++ b/src/views/console/ConsoleLayout.tsx
@@ -1,0 +1,78 @@
+import Link from 'next/link'
+import { useMemo, type ReactNode } from 'react'
+import type { ConsolePageBaseProps, ConsoleTabKey } from './types'
+import { useTranslation } from 'next-i18next'
+
+interface ConsoleLayoutProps extends ConsolePageBaseProps {
+  activeTab: ConsoleTabKey
+  children: ReactNode
+}
+
+export default function ConsoleLayout({
+  user,
+  locale,
+  activeTab,
+  children,
+}: ConsoleLayoutProps) {
+  const { t } = useTranslation('common')
+
+  const items = useMemo(() => {
+    const basePath = `/${locale}/console`
+    return [
+      { key: 'overview' as const, href: basePath, label: t('Console.nav.overview') },
+      {
+        key: 'account' as const,
+        href: `${basePath}/account`,
+        label: t('Console.nav.account'),
+      },
+      {
+        key: 'posts' as const,
+        href: `${basePath}/posts`,
+        label: t('Console.nav.posts'),
+      },
+      {
+        key: 'favorites' as const,
+        href: `${basePath}/favorites`,
+        label: t('Console.nav.favorites'),
+      },
+    ]
+  }, [locale, t])
+
+  return (
+    <div className="bg-neutral-50 min-h-screen">
+      <div className="mx-auto max-w-5xl px-4 py-10 space-y-6">
+        <header className="space-y-2">
+          <p className="text-sm text-neutral-500">
+            {t('Console.greeting', { name: user.name })}
+          </p>
+          <h1 className="text-2xl font-semibold text-neutral-900">
+            {t('Console.heading')}
+          </h1>
+        </header>
+        <nav aria-label={t('Console.nav.ariaLabel')} className="border-b border-neutral-200">
+          <ul className="flex flex-wrap gap-4 pb-2">
+            {items.map((item) => {
+              const isActive = item.key === activeTab
+              return (
+                <li key={item.key}>
+                  <Link
+                    href={item.href}
+                    className={`pb-2 border-b-2 text-sm font-medium transition-colors ${
+                      isActive
+                        ? 'border-emerald-500 text-emerald-600'
+                        : 'border-transparent text-neutral-600 hover:text-neutral-900'
+                    }`}
+                    aria-current={isActive ? 'page' : undefined}
+                  >
+                    {item.label}
+                  </Link>
+                </li>
+              )
+            })}
+          </ul>
+        </nav>
+        <main className="space-y-6">{children}</main>
+      </div>
+    </div>
+  )
+}

--- a/src/views/console/ConsoleOverviewView.tsx
+++ b/src/views/console/ConsoleOverviewView.tsx
@@ -1,0 +1,99 @@
+import { useTranslation } from 'next-i18next'
+import ConsoleLayout from './ConsoleLayout'
+import type { ConsolePageBaseProps } from './types'
+import { createConsoleGetServerSideProps } from './consoleServer'
+import { ConsoleUserProvider } from '@/context/ConsoleUserContext'
+import { useFavoritesQuota } from '@/hooks/useFavoritesQuota'
+import { useConsolePaywall } from '@/hooks/useConsolePaywall'
+
+interface ConsoleOverviewViewProps extends ConsolePageBaseProps {}
+
+function StatCard({
+  title,
+  value,
+  helper,
+}: {
+  title: string
+  value: string
+  helper?: string
+}) {
+  return (
+    <div className="rounded-lg border border-neutral-200 bg-white p-4 shadow-sm">
+      <p className="text-sm font-medium text-neutral-500">{title}</p>
+      <p className="mt-2 text-2xl font-semibold text-neutral-900">{value}</p>
+      {helper && <p className="mt-2 text-xs text-neutral-500">{helper}</p>}
+    </div>
+  )
+}
+
+function ConsoleOverviewContent(props: ConsoleOverviewViewProps) {
+  const { user } = props
+  const { t } = useTranslation('common')
+  const favorites = useFavoritesQuota()
+  const paywall = useConsolePaywall()
+
+  return (
+    <ConsoleLayout {...props} activeTab="overview">
+      <section className="grid grid-cols-1 gap-4 md:grid-cols-3">
+        <StatCard
+          title={t('Console.overview.plan')}
+          value={t(`Console.plans.${user.plan}`)}
+          helper={t('Console.overview.planHelper')}
+        />
+        <StatCard
+          title={t('Console.overview.posts')}
+          value={`${paywall.used}/${paywall.limit}`}
+          helper={paywall.message}
+        />
+        <StatCard
+          title={t('Console.overview.favorites')}
+          value={`${favorites.used}/${favorites.limit}`}
+          helper={
+            favorites.isAtLimit
+              ? t('Console.overview.favoritesLimit')
+              : t('Console.overview.favoritesRemaining', {
+                  count: favorites.remaining,
+                })
+          }
+        />
+      </section>
+      {paywall.showPaywall && (
+        <section className="rounded-lg border border-amber-300 bg-amber-50 p-6">
+          <h2 className="text-lg font-semibold text-amber-900">
+            {t('Console.paywall.title')}
+          </h2>
+          <p className="mt-2 text-sm text-amber-800">{t('Console.paywall.description')}</p>
+          <div className="mt-4 flex flex-wrap gap-3">
+            <button className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-semibold text-white">
+              {t('Console.paywall.upgradeCta')}
+            </button>
+            <button className="rounded-md border border-emerald-200 px-4 py-2 text-sm font-semibold text-emerald-700">
+              {t('Console.paywall.contactCta')}
+            </button>
+          </div>
+        </section>
+      )}
+      <section className="rounded-lg border border-neutral-200 bg-white p-6 shadow-sm">
+        <h2 className="text-lg font-semibold text-neutral-900">
+          {t('Console.overview.activityTitle')}
+        </h2>
+        <p className="mt-2 text-sm text-neutral-600">
+          {t('Console.overview.activityDescription')}
+        </p>
+      </section>
+    </ConsoleLayout>
+  )
+}
+
+export default function ConsoleOverviewView(props: ConsoleOverviewViewProps) {
+  return (
+    <ConsoleUserProvider initialUser={props.user}>
+      <ConsoleOverviewContent {...props} />
+    </ConsoleUserProvider>
+  )
+}
+
+export const getServerSideProps = createConsoleGetServerSideProps({
+  seoPath: '/console',
+  seoTitle: 'Console Overview',
+})

--- a/src/views/console/ConsolePostsView.tsx
+++ b/src/views/console/ConsolePostsView.tsx
@@ -1,0 +1,93 @@
+import { useMemo } from 'react'
+import { useTranslation } from 'next-i18next'
+import ConsoleLayout from './ConsoleLayout'
+import type { ConsolePageBaseProps } from './types'
+import { createConsoleGetServerSideProps } from './consoleServer'
+import { useConsolePaywall } from '@/hooks/useConsolePaywall'
+import { ConsoleUserProvider } from '@/context/ConsoleUserContext'
+
+interface ConsolePostsViewProps extends ConsolePageBaseProps {}
+
+function ConsolePostsContent(props: ConsolePostsViewProps) {
+  const { user } = props
+  const { t } = useTranslation('common')
+  const paywall = useConsolePaywall()
+
+  const posts = useMemo(
+    () =>
+      Array.from({ length: user.postsUsed }, (_, index) => ({
+        id: `${index + 1}`,
+        title: t('Console.posts.placeholderTitle', { index: index + 1 }),
+        status: index % 2 === 0 ? 'published' : 'draft',
+      })),
+    [user.postsUsed, t],
+  )
+
+  return (
+    <ConsoleLayout {...props} activeTab="posts">
+      <section className="rounded-lg border border-neutral-200 bg-white p-6 shadow-sm space-y-4">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <h2 className="text-lg font-semibold text-neutral-900">
+              {t('Console.posts.title')}
+            </h2>
+            <p className="text-sm text-neutral-500">{paywall.message}</p>
+          </div>
+          <button
+            type="button"
+            className={`rounded-md px-4 py-2 text-sm font-semibold transition-colors ${
+              paywall.showPaywall
+                ? 'cursor-not-allowed bg-neutral-200 text-neutral-500'
+                : 'bg-emerald-600 text-white hover:bg-emerald-700'
+            }`}
+            disabled={paywall.showPaywall}
+          >
+            {paywall.showPaywall
+              ? t('Console.paywall.upgradeCta')
+              : t('Console.posts.createCta')}
+          </button>
+        </div>
+        {paywall.showPaywall && (
+          <div className="rounded-md border border-amber-300 bg-amber-50 p-4 text-sm text-amber-900">
+            {t('Console.posts.paywallHint')}
+          </div>
+        )}
+        <ul className="divide-y divide-neutral-200">
+          {posts.length === 0 && (
+            <li className="py-6 text-sm text-neutral-500">
+              {t('Console.posts.emptyState')}
+            </li>
+          )}
+          {posts.map((post) => (
+            <li key={post.id} className="py-4">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <p className="text-sm font-semibold text-neutral-900">{post.title}</p>
+                  <p className="text-xs uppercase tracking-wide text-neutral-400">
+                    {t(`Console.posts.status.${post.status}`)}
+                  </p>
+                </div>
+                <button className="text-sm font-semibold text-emerald-600 hover:text-emerald-700">
+                  {t('Console.posts.manageCta')}
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </ConsoleLayout>
+  )
+}
+
+export default function ConsolePostsView(props: ConsolePostsViewProps) {
+  return (
+    <ConsoleUserProvider initialUser={props.user}>
+      <ConsolePostsContent {...props} />
+    </ConsoleUserProvider>
+  )
+}
+
+export const getServerSideProps = createConsoleGetServerSideProps({
+  seoPath: '/console/posts',
+  seoTitle: 'Console Posts',
+})

--- a/src/views/console/consoleServer.ts
+++ b/src/views/console/consoleServer.ts
@@ -1,0 +1,92 @@
+import type { GetServerSideProps, GetServerSidePropsContext } from 'next'
+import { parseCookies } from '@/lib/http/cookies'
+import {
+  CONSOLE_LOCALE_COOKIE,
+  type ConsoleUserSession,
+  getConsoleUserFromCookies,
+} from '@/lib/auth/consoleSession'
+import { getLanguageAlternates, getSeoUrls } from '@/lib/seo'
+import type { ConsolePageBaseProps, ConsoleHeadProps } from './types'
+
+interface ConsoleGuardOptions {
+  seoPath: string
+  seoTitle: string
+}
+
+interface ConsoleGuardSuccess extends ConsolePageBaseProps {}
+
+function buildHead(locale: string, path: string, title: string): ConsoleHeadProps {
+  const { pageUrl } = getSeoUrls(locale, path)
+  return {
+    seo: {
+      title,
+      canonical: pageUrl,
+      languageAlternates: getLanguageAlternates(path),
+    },
+  }
+}
+
+function resolvePreferredLocale(
+  user: ConsoleUserSession,
+  cookies: Record<string, string>,
+  fallback: string,
+): string {
+  return user.localePreference || cookies[CONSOLE_LOCALE_COOKIE] || fallback
+}
+
+function stripLeadingLocale(path: string): string {
+  return path.replace(/^\/[^/]+/, '')
+}
+
+export function createConsoleGetServerSideProps<
+  P extends Record<string, unknown> = Record<string, never>,
+>(
+  options: ConsoleGuardOptions,
+  extend?: (
+    ctx: GetServerSidePropsContext,
+    base: ConsoleGuardSuccess,
+  ) => Promise<P> | P,
+): GetServerSideProps<ConsoleGuardSuccess & P> {
+  return async (ctx) => {
+    const { req, resolvedUrl, locale, defaultLocale } = ctx
+    const activeLocale = locale || defaultLocale || 'th'
+    const cookies = parseCookies(req.headers.cookie)
+    const user = getConsoleUserFromCookies(cookies)
+
+    if (!user) {
+      const destination = `/${activeLocale}/?console=signin`
+      return { redirect: { destination, permanent: false } }
+    }
+
+    const preferredLocale = resolvePreferredLocale(user, cookies, activeLocale)
+    if (preferredLocale !== activeLocale) {
+      const pathSuffix = stripLeadingLocale(resolvedUrl)
+      return {
+        redirect: {
+          destination: `/${preferredLocale}${pathSuffix}`,
+          permanent: false,
+        },
+      }
+    }
+
+    const head = buildHead(activeLocale, options.seoPath, options.seoTitle)
+
+    const baseProps: ConsoleGuardSuccess = {
+      locale: activeLocale,
+      user: {
+        ...user,
+        localePreference: preferredLocale,
+      },
+      head,
+    }
+
+    if (!extend) {
+      return { props: baseProps as ConsoleGuardSuccess & P }
+    }
+
+    const extra = await extend(ctx, baseProps)
+    return {
+      props: { ...baseProps, ...extra },
+    }
+  }
+}

--- a/src/views/console/types.ts
+++ b/src/views/console/types.ts
@@ -1,0 +1,14 @@
+import type { NextSeoProps } from 'next-seo'
+import type { ConsoleUser } from '@/context/ConsoleUserContext'
+
+export type ConsoleTabKey = 'overview' | 'account' | 'posts' | 'favorites'
+
+export interface ConsoleHeadProps {
+  seo: NextSeoProps
+}
+
+export interface ConsolePageBaseProps {
+  locale: string
+  user: ConsoleUser
+  head: ConsoleHeadProps
+}


### PR DESCRIPTION
## Summary
- add a console hub entry point to the global navigation
- introduce console user context, quota hooks, and SSR guard helpers
- build localized console views and pages for overview, account, posts, and favorites with new translations

## Testing
- npm run lint
- npm run typecheck (fails: existing minisearch typing errors and prisma seed type issues)


------
https://chatgpt.com/codex/tasks/task_e_68ccc79a1b14832ba283ab7072e7ea41