### PR TITLE
Use PropertyImage in search suggestions

### DIFF
--- a/src/components/search/SearchPanel.tsx
+++ b/src/components/search/SearchPanel.tsx
@@ -9,6 +9,7 @@ import {
   type KeyboardEvent,
 } from 'react'
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion'
+import PropertyImage from '@/components/PropertyImage'
 
 export type SearchLocale = 'en' | 'th' | 'zh'
 
@@ -262,11 +263,12 @@ export default function SearchPanel({
                       onMouseDown={(event) => event.preventDefault()}
                       onClick={() => handleSuggestionClick(item.title)}
                     >
-                      <img
+                      <PropertyImage
                         src={item.image}
-                        alt=""
-                        width={48}
-                        height={48}
+                        alt={item.title}
+                        w={48}
+                        h={48}
+                        sizes="48px"
                         className="h-12 w-12 flex-shrink-0 rounded object-cover"
                       />
                       <span className="text-sm font-medium text-neutral-900">{item.title}</span>


### PR DESCRIPTION
## Summary
- update search panel suggestion thumbnails to use the shared PropertyImage component
- pass appropriate sizing, alt text, and styling props to maintain layout

## Testing
- npm run typecheck *(fails: missing minisearch module and prisma type exports in existing codebase)*

------
https://chatgpt.com/codex/tasks/task_e_68ccd83f9e90832b9651fa82bb23ada5