### PR TITLE
Refine MiniSearch typing for serialized indexes

### DIFF
--- a/minisearch.d.ts
+++ b/minisearch.d.ts
@@ -1,0 +1,5 @@
+declare module 'minisearch' {
+  import MiniSearch from 'mini-search'
+  export * from 'mini-search'
+  export default MiniSearch
+}


### PR DESCRIPTION
## Summary
- expose MiniSearch option field lists as readonly constants and spread them when loading legacy indexes
- load serialized index JSON with typed options in both the API route and worker, inferring `MiniSearch<SearchDoc>`
- add a local module declaration to surface the `mini-search` type definitions under the `minisearch` import path

## Testing
- npm run typecheck *(fails: existing Prisma client enums and DOM KeyboardEvent typing issues)*

------
https://chatgpt.com/codex/tasks/task_e_68ccdacf3e98832b801872c17a35d04a